### PR TITLE
Revert "Fix alignment issues" due to slice bug

### DIFF
--- a/wastrumentation-instr-lib/src/lib_gen/instrumentation/rust/mod.rs
+++ b/wastrumentation-instr-lib/src/lib_gen/instrumentation/rust/mod.rs
@@ -2,7 +2,6 @@ use std::{collections::HashSet, marker::PhantomData, ops::Deref, vec};
 
 use crate::lib_compile::rust::options::{ManifestSource, RustSource, RustSourceCode};
 use crate::lib_compile::rust::Rust;
-use std::iter;
 use rust_to_wasm_compiler::WasiSupport;
 use wastrumentation::{
     compiler::{LibGeneratable, Library},
@@ -119,13 +118,11 @@ impl RustSignature<'_> {
         if rets_count + args_count == 0 {
             "0".to_string()
         } else {
-            let tys = Self::rust_generics(rets_count, args_count);
-            // types shifted with an offset of 1
-            let tys1 = &tys.as_slice()[1..];
-            tys.iter()
-                .zip(tys1.iter().chain(iter::once(&"()".to_string())))
-                .fold("0".to_string(), |state, (ty, ty1)|
-                    format!("{state} + size_of::<{ty}>() + roundup::<{ty1}>(size_of::<{ty}>() + {state})"))
+            Self::rust_generics(rets_count, args_count)
+                .iter()
+                .map(|ty| format!("size_of::<{ty}>()"))
+                .collect::<Vec<String>>()
+                .join(" + ")
         }
     }
 }
@@ -134,15 +131,19 @@ fn generics_offset(position: usize, rets_count: usize, args_offset: usize) -> St
     if position == 0 {
         return "0".into();
     };
+    let ret_offsets: Vec<String> = (0..rets_count)
+        .map(|n| format!("size_of::<R{n}>()"))
+        .collect();
+    let arg_offsets: Vec<String> = (0..args_offset)
+        .map(|n| format!("size_of::<T{n}>()"))
+        .collect();
 
-    let ret_names  =  (0..rets_count).map(|n| format!("R{n}")).collect::<Vec<String>>();
-    let ret_names1 = &ret_names.as_slice()[1..];
-    let arg_names = (0..args_offset).map(|n| format!("T{n}")).collect::<Vec<String>>();
-
-    ret_names.iter().chain(arg_names.iter())
-        .zip(ret_names1.iter().chain(arg_names.iter()).chain(iter::once(&"()".to_string())))
+    ret_offsets
+        .into_iter()
+        .chain(arg_offsets)
         .take(position)
-        .fold("0".to_string(), |state, (ty, ty1)| format!("{state} + size_of::<{ty}>() + roundup::<{ty1}>(size_of::<{ty}>() + {state})"))
+        .collect::<Vec<String>>()
+        .join(" + ")
 }
 
 fn arg_offset(arg_pos: usize, rets_count: usize, args_count: usize) -> String {
@@ -584,12 +585,6 @@ fn wastrumentation_memory_store<T>(stack_ptr: usize, value: T, offset: usize) {
     unsafe {
         *(ptr.offset(offset as isize) as *mut T) = value;
     }
-}
-
-#[inline(always)]
-fn roundup<T2>(siz: usize) -> usize {
-    if siz % align_of::<T2>() == 0 { return 0; }
-    align_of::<T2>() - (siz % align_of::<T2>())
 }
 
 #[inline(always)]

--- a/wastrumentation-instr-lib/src/lib_gen/instrumentation/rust/tests/test_edge_case.rs
+++ b/wastrumentation-instr-lib/src/lib_gen/instrumentation/rust/tests/test_edge_case.rs
@@ -91,7 +91,7 @@ fn test_edge_rust() {
 
     // Assert execution
     // FIXME:
-    assert_lib_with_use_case(instrumentation_wasm_library);
+    // assert_lib_with_use_case(instrumentation_wasm_library);
 }
 
 #[test]


### PR DESCRIPTION
Thanks for your contribution & time, however I am reversing aaronmunsters/wastrumentation#7 for now.

Reason being the instrumentation phase panics for the following signature: `inputs: vec![], results: vec[I64]`.

```
... panicked at wastrumentation-instr-lib/src/lib_gen/instrumentation/rust/mod.rs:141:43:
range start index 1 out of range for slice of length 0
```

This is pointed out by the following unit test case on line 85: [`compute_memory_offset_generically_works_correctly`](https://github.com/aaronmunsters/wastrumentation/blob/ac6109b5958c4540f6ae1b96b97d69a4a072ee25/wastrumentation-instr-lib/src/lib_gen/instrumentation/rust/tests/mod.rs#L85).
 
Furthermore this is mishap is triggered by the integration test when changing the `ASCompiler` to `Compiler` (using your altered version) on line 106 in [`wastrumentation-instr-lib/tests/memory_introspection.rs`](https://github.com/aaronmunsters/wastrumentation/blob/ac6109b5958c4540f6ae1b96b97d69a4a072ee25/wastrumentation-instr-lib/tests/memory_introspection.rs#L106).

In addition, quite a few more tests start to fail, but most of them are quickly fixed by changing the hardcoded expected string content.
Alternatively the hardcoded strings could be replaced with regex match assertions & some unit tests that validate if the Rust compiler accepts the input program.
This would reduce the overall churn, however is a weaker assertion.