### PR TITLE
Update dependencies, allow Rust for instrumentation infrastructure generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.dependencies]
-# Crates defined in this project
+# Crates defined as part of Wastrumentation
 asc-compiler-rs = { git = "https://github.com/aaronmunsters/asc-compiler-rs", rev = "779738e" }
 rust-to-wasm-compiler = { git = "https://github.com/aaronmunsters/rust-to-wasm-compiler", rev = "363a3a6" }
 wastrumentation = { path = "./wastrumentation" }
@@ -19,7 +19,7 @@ wastrumentation-instr-lib = { path = "./wastrumentation-instr-lib" }
 wasp-compiler = { path = "./wasp-compiler" }
 wasm-merge = { path = "./wasm-merge" }
 
-wasmtime = "34.0"
+wasmtime = "35.0"
 indoc = "2"
 tempfile = "3.20"
 serde = { version = "1.0", features = ["derive"] }

--- a/benchmarking-node/input-analyses/rust/safe-heap/src/lib.rs
+++ b/benchmarking-node/input-analyses/rust/safe-heap/src/lib.rs
@@ -7,7 +7,6 @@
 // top of sbrk()-addressible memory, and incorrect alignment notation.
 
 #![no_std]
-#![feature(strict_overflow_ops)]
 use wastrumentation_rs_stdlib::*;
 
 const SIZE_AS_BYTES: i64 = i64::pow(2, 16);

--- a/wasm-merge/Cargo.toml
+++ b/wasm-merge/Cargo.toml
@@ -8,6 +8,6 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-wat = { version = "1.228.0" }
+wat = { version = "1.236.0" }
 wasmtime = { workspace = true }
 indoc = { workspace = true }

--- a/wasp-compiler/Cargo.toml
+++ b/wasp-compiler/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2021"
 [dependencies]
 thiserror = { workspace = true }
 indoc = { workspace = true }
-from-pest = "0.3.3"
-pest = "2.7"
-pest-ast = "0.3.5"
-pest_derive = "2.7"
+from-pest = "0.3.4"
+pest = "2.8"
+pest-ast = "0.3.6"
+pest_derive = "2.8"
 
 [dev-dependencies]
 pest-test = "0.1.6"

--- a/wastrumentation-instr-lib/Cargo.toml
+++ b/wastrumentation-instr-lib/Cargo.toml
@@ -19,5 +19,5 @@ rayon = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 wat = { workspace = true }
-wasmtime-wasi = "34.0"
+wasmtime-wasi = "35.0"
 wastrumentation-static-analysis = { path = "../wastrumentation-static-analysis" }

--- a/wastrumentation-instr-lib/src/lib_compile/rust/compiler.rs
+++ b/wastrumentation-instr-lib/src/lib_compile/rust/compiler.rs
@@ -12,6 +12,7 @@ pub struct Compiler {
     compiler: RustToWasmCompiler,
 }
 
+// TODO: for tests suite, would be nice to cover Profile::Release & Profile::Dev
 impl DefaultCompilerOptions<Rust> for CompilerOptions {
     fn default_for(source: RustSource) -> Self {
         Self {

--- a/wastrumentation-instr-lib/src/lib_gen/instrumentation/assemblyscript/lib_boilerplate.ts
+++ b/wastrumentation-instr-lib/src/lib_gen/instrumentation/assemblyscript/lib_boilerplate.ts
@@ -1,6 +1,8 @@
 let $STACK_FREE_PTR: usize = 0;
 let $TOTAL_MEMORY: usize = 0;
 const $MEMORY_GROWTH_SIZE: usize = 1;
+const SIZE_WASM_VALUE: usize = sizeof<i64>();
+const SIZE_WASM_TYPE: usize = sizeof<i32>();
 
 @inline
 function grow_memory(): void {
@@ -35,37 +37,67 @@ function stack_deallocate(_ptr: usize, bytes: usize): void {
 }
 
 @inline
+function stack_allocate_values(count: usize): usize {
+    return stack_allocate(count * SIZE_WASM_VALUE);
+}
+
+@inline
+function stack_deallocate_values(_ptr: usize, count: usize): void {
+    stack_deallocate(_ptr, count * SIZE_WASM_VALUE);
+}
+
+@inline
+function stack_allocate_types(count: usize): usize {
+    return stack_allocate(count * SIZE_WASM_TYPE);
+}
+
+@inline
+function stack_deallocate_types(_ptr: usize, count: usize): void {
+    stack_deallocate(_ptr, count * SIZE_WASM_TYPE);
+}
+
+@inline
+export function wastrumentation_stack_load_type(ptr: usize, offset: usize): i32 {
+    return load<i32>(ptr + (offset * SIZE_WASM_TYPE), 0);
+};
+
+@inline
+export function wastrumentation_stack_store_type(ptr: usize, offset: usize, ty: i32): void {
+    store<i32>(ptr + (offset * SIZE_WASM_TYPE), ty);
+};
+
+@inline
 export function wastrumentation_stack_load_i32(ptr: usize, offset: usize): i32 {
-    return load<i32>(ptr + offset, 0);
+    return load<i32>(ptr + (offset * SIZE_WASM_VALUE), 0);
 };
 @inline
 export function wastrumentation_stack_load_f32(ptr: usize, offset: usize): f32 {
-    return load<f32>(ptr + offset, 0);
+    return load<f32>(ptr + (offset * SIZE_WASM_VALUE), 0);
 };
 @inline
 export function wastrumentation_stack_load_i64(ptr: usize, offset: usize): i64 {
-    return load<i64>(ptr + offset, 0);
+    return load<i64>(ptr + (offset * SIZE_WASM_VALUE), 0);
 };
 @inline
 export function wastrumentation_stack_load_f64(ptr: usize, offset: usize): f64 {
-    return load<f64>(ptr + offset, 0);
+    return load<f64>(ptr + (offset * SIZE_WASM_VALUE), 0);
 };
 
 @inline
 export function wastrumentation_stack_store_i32(ptr: usize, value: i32, offset: usize): void {
-    return store<i32>(ptr + offset, value);
+    return store<i32>(ptr + (offset * SIZE_WASM_VALUE), value);
 };
 @inline
 export function wastrumentation_stack_store_f32(ptr: usize, value: f32, offset: usize): void {
-    return store<f32>(ptr + offset, value);
+    return store<f32>(ptr + (offset * SIZE_WASM_VALUE), value);
 };
 @inline
 export function wastrumentation_stack_store_i64(ptr: usize, value: i64, offset: usize): void {
-    return store<i64>(ptr + offset, value);
+    return store<i64>(ptr + (offset * SIZE_WASM_VALUE), value);
 };
 @inline
 export function wastrumentation_stack_store_f64(ptr: usize, value: f64, offset: usize): void {
-    return store<f64>(ptr + offset, value);
+    return store<f64>(ptr + (offset * SIZE_WASM_VALUE), value);
 };
 
 function wastrumentation_memory_load<T>(ptr: usize, offset: usize): T {

--- a/wastrumentation-instr-lib/src/lib_gen/instrumentation/assemblyscript/mod.rs
+++ b/wastrumentation-instr-lib/src/lib_gen/instrumentation/assemblyscript/mod.rs
@@ -85,43 +85,23 @@ impl WaspSignature<'_> {
     fn assemblyscript_generic_comma_separated_typed_arguments(args_count: usize) -> String {
         Self::assemblyscript_generic_typed_arguments(args_count).join(", ")
     }
+}
 
-    fn assemblyscript_compute_type_allocation(rets_count: usize, args_count: usize) -> String {
-        if rets_count + args_count == 0 {
-            "0".to_string()
-        } else {
-            Self::assemblyscript_generics(rets_count, args_count)
-                .iter()
-                .map(|ty| format!("sizeof<{ty}>()"))
-                .collect::<Vec<String>>()
-                .join(" + ")
-        }
+// Updated offset calculations to use index-based addressing for WasmValue unions
+fn value_index_offset(position: usize) -> String {
+    if position == 0 {
+        "0".into()
+    } else {
+        position.to_string()
     }
 }
 
-fn generics_offset(position: usize, rets_count: usize, args_offset: usize) -> String {
-    if position == 0 {
-        return "0".into();
-    };
-    let ret_offsets: Vec<String> = (0..rets_count).map(|n| format!("sizeof<R{n}>()")).collect();
-    let arg_offsets: Vec<String> = (0..args_offset)
-        .map(|n| format!("sizeof<T{n}>()"))
-        .collect();
-
-    ret_offsets
-        .into_iter()
-        .chain(arg_offsets)
-        .take(position)
-        .collect::<Vec<String>>()
-        .join(" + ")
+fn arg_index_offset(arg_pos: usize, rets_count: usize) -> String {
+    value_index_offset(rets_count + arg_pos)
 }
 
-fn arg_offset(arg_pos: usize, rets_count: usize, args_count: usize) -> String {
-    generics_offset(rets_count + arg_pos, rets_count, args_count)
-}
-
-fn ret_offset(ret_pos: usize, rets_count: usize, args_count: usize) -> String {
-    generics_offset(ret_pos, rets_count, args_count)
+fn ret_index_offset(ret_pos: usize) -> String {
+    value_index_offset(ret_pos)
 }
 
 fn generate_allocate_generic(rets_count: usize, args_count: usize) -> String {
@@ -131,28 +111,29 @@ fn generate_allocate_generic(rets_count: usize, args_count: usize) -> String {
         WaspSignature::assemblyscript_generic_comma_separated_typed_arguments(args_count);
     let generic_name = WaspSignature::generic_assemblyscript_name(rets_count, args_count);
 
-    // eg: `sizeof<R0>() +  sizeof<R1>() +  sizeof<T0>() +  sizeof<T1>()`
-    let total_allocation =
-        WaspSignature::assemblyscript_compute_type_allocation(rets_count, args_count);
-    let all_stores_followed_by_return = (0..args_count)
-        .map(|n| {
-            let offset = arg_offset(n, rets_count, args_count);
-            format!(
-                "// store a{n}
-    const a{n}_offset = {offset}; // constant folded
-    wastrumentation_memory_store<T{n}>(stack_begin, a{n}, a{n}_offset); // inlined"
-            )
-        })
-        .chain(vec!["return stack_begin;".into()])
-        .collect::<Vec<String>>()
-        .join("\n    ");
+    let total_allocation = rets_count + args_count;
+
+    let all_stores_followed_by_return = if args_count == 0 {
+        "return stack_begin;".to_string()
+    } else {
+        (0..args_count)
+            .map(|n| {
+                let offset = arg_index_offset(n, rets_count);
+                format!(
+                    "// store a{n}
+    wastrumentation_memory_store<T{n}>(stack_begin, a{n}, {offset});"
+                )
+            })
+            .chain(vec!["return stack_begin;".into()])
+            .collect::<Vec<String>>()
+            .join("\n    ")
+    };
 
     format!(
         "
 @inline
 function allocate_{generic_name}{string_all_generics}({signature}): usize {{
-    const to_allocate = {total_allocation}; // constant folded
-    const stack_begin = stack_allocate(to_allocate); // inlined
+    const stack_begin = stack_allocate_values({total_allocation}); // inlined
     {all_stores_followed_by_return}
 }}"
     )
@@ -191,14 +172,14 @@ export function {mangled_name}({signature_args_typs_ident}): usize {{
 }
 
 fn generate_allocate_types_buffer_generic(rets_count: usize, args_count: usize) -> String {
-    let total_allocation = format!("sizeof<i32>() * {};", rets_count + args_count);
+    // Types are stored as i32 values, not WasmValues
+    let total_allocation = rets_count + args_count;
     let generic_name = WaspSignature::generic_assemblyscript_name(rets_count, args_count);
     format!(
         "
 @inline
 function allocate_signature_types_buffer_{generic_name}(): usize {{
-    const to_allocate = {total_allocation}; // constant folded
-    const stack_begin = stack_allocate(to_allocate); // inlined
+    const stack_begin = stack_allocate_types({total_allocation}); // inlined
     return stack_begin;
 }}"
     )
@@ -216,7 +197,7 @@ fn generate_allocate_types_buffer_specialized(signature: &WaspSignature) -> Stri
         .map(WasmType::runtime_enum_value)
         .enumerate()
         .map(|(index, enum_value)| {
-            format!("wastrumentation_memory_store<i32>(types_buffer, {enum_value}, (sizeof<i32>()*{index}));")
+            format!("wastrumentation_stack_store_type(types_buffer, {index}, {enum_value});")
         })
         .chain(vec!["return types_buffer;".into()])
         .collect::<Vec<String>>()
@@ -240,24 +221,22 @@ fn generate_load_generic(rets_count: usize, args_count: usize) -> String {
     let generic_name = WaspSignature::generic_assemblyscript_name(rets_count, args_count);
 
     let all_arg_loads = (0..args_count).map(|n| {
-        let an_offset = arg_offset(n, rets_count, args_count);
+        let an_offset = arg_index_offset(n, rets_count);
         format!(
             "
 @inline
 function load_arg{n}_{generic_name}{string_all_generics}(stack_ptr: usize): T{n} {{
-    const a{n}_offset = {an_offset}; // constant folded
-    return wastrumentation_memory_load<T{n}>(stack_ptr, a{n}_offset); // inlined
+    return wastrumentation_memory_load<T{n}>(stack_ptr, {an_offset});
 }}"
         )
     });
     let all_ret_loads = (0..rets_count).map(|n| {
-        let ar_offset = ret_offset(n, rets_count, args_count);
+        let ar_offset = ret_index_offset(n);
         format!(
             "
 @inline
 function load_ret{n}_{generic_name}{string_all_generics}(stack_ptr: usize): R{n} {{
-    const r{n}_offset = {ar_offset}; // constant folded
-    return wastrumentation_memory_load<R{n}>(stack_ptr, r{n}_offset); // inlined
+    return wastrumentation_memory_load<R{n}>(stack_ptr, {ar_offset});
 }}"
         )
     });
@@ -313,24 +292,22 @@ fn generate_store_generic(rets_count: usize, args_count: usize) -> String {
     let generic_name = WaspSignature::generic_assemblyscript_name(rets_count, args_count);
 
     let all_arg_stores = (0..args_count).map(|n| {
-        let an_offset = arg_offset(n, rets_count, args_count);
+        let an_offset = arg_index_offset(n, rets_count);
         format!(
             "
 @inline
 function store_arg{n}_{generic_name}{string_all_generics}(stack_ptr: usize, a{n}: T{n}): void {{
-    const a{n}_offset = {an_offset}; // constant folded
-    return wastrumentation_memory_store<T{n}>(stack_ptr, a{n}, a{n}_offset); // inlined
+    return wastrumentation_memory_store<T{n}>(stack_ptr, a{n}, {an_offset});
 }}"
         )
     });
     let all_ret_stores = (0..rets_count).map(|n| {
-        let ar_offset = ret_offset(n, rets_count, args_count);
+        let ar_offset = ret_index_offset(n);
         format!(
             "
 @inline
 function store_ret{n}_{generic_name}{string_all_generics}(stack_ptr: usize, r{n}: R{n}): void {{
-    const r{n}_offset = {ar_offset}; // constant folded
-    return wastrumentation_memory_store<R{n}>(stack_ptr, r{n}, r{n}_offset); // inlined
+    return wastrumentation_memory_store<R{n}>(stack_ptr, r{n}, {ar_offset});
 }}"
         )
     });
@@ -384,16 +361,14 @@ fn generate_free_values_buffer_generic(rets_count: usize, args_count: usize) -> 
         WaspSignature::assemblyscript_comma_separated_generics(rets_count, args_count);
     let generic_name = WaspSignature::generic_assemblyscript_name(rets_count, args_count);
 
-    // eg: `sizeof<R0>() +  sizeof<R1>() +  sizeof<T0>() +  sizeof<T1>()`
-    let total_allocation =
-        WaspSignature::assemblyscript_compute_type_allocation(rets_count, args_count);
+    // Use the same allocation calculation as allocate function
+    let total_allocation = rets_count + args_count;
 
     format!(
         "
 @inline
 function free_values_{generic_name}{string_all_generics}(ptr: usize): void {{
-    const to_deallocate = {total_allocation}; // constant folded
-    stack_deallocate(ptr, to_deallocate); // inlined
+    stack_deallocate_values(ptr, {total_allocation}); // inlined
     return;
 }}"
     )
@@ -413,14 +388,13 @@ export function {}(ptr: usize): void {{
 
 fn generate_free_types_buffer_generic(rets_count: usize, args_count: usize) -> String {
     let generic_name = WaspSignature::generic_assemblyscript_name(rets_count, args_count);
-    let total_allocation = format!("sizeof<i32>() * {};", rets_count + args_count);
+    let total_allocation = rets_count + args_count;
 
     format!(
         "
 @inline
 function free_types_{generic_name}(ptr: usize): void {{
-    const to_deallocate = {total_allocation}; // constant folded
-    stack_deallocate(ptr, to_deallocate); // inlined
+    stack_deallocate_types(ptr, {total_allocation}); // inlined
     return;
 }}"
     )
@@ -449,16 +423,21 @@ fn generate_store_rets_generic(rets_count: usize, args_count: usize) -> String {
         .chain(array_of_rets_signature)
         .collect::<Vec<String>>()
         .join(", ");
-    let all_stores = (0..rets_count)
-        .flat_map(|n| {
-            vec![
-                format!("// store a{n}"),
-                format!("store_ret{n}_{generic_name}{string_all_generics}(stack_ptr, a{n});"),
-            ]
-        })
-        .chain(vec!["return;".into()])
-        .collect::<Vec<String>>()
-        .join("\n    ");
+
+    let all_stores = if rets_count == 0 {
+        "return;".to_string()
+    } else {
+        (0..rets_count)
+            .flat_map(|n| {
+                vec![
+                    format!("// store a{n}"),
+                    format!("store_ret{n}_{generic_name}{string_all_generics}(stack_ptr, a{n});"),
+                ]
+            })
+            .chain(vec!["return;".into()])
+            .collect::<Vec<String>>()
+            .join("\n    ")
+    };
 
     format!(
         "
@@ -595,47 +574,13 @@ mod tests {
     }
 
     #[test]
-    fn compute_memory_offset_generically_works_correctly() {
-        let pos_frst = 0;
-        let pos_scnd = 1;
-        let pos_thrd = 2;
-        let pos_frth = 3;
-        for ((position, ret_count, arg_offset), expected) in [
-            ((pos_frst, 0, 1), "0"),
-            ((pos_frst, 0, 2), "0"),
-            ((pos_scnd, 0, 2), "sizeof<T0>()"),
-            ((pos_frst, 1, 0), "0"),
-            ((pos_frst, 1, 1), "0"),
-            ((pos_scnd, 1, 1), "sizeof<R0>()"),
-            ((pos_frst, 1, 2), "0"),
-            ((pos_scnd, 1, 2), "sizeof<R0>()"),
-            ((pos_thrd, 1, 2), "sizeof<R0>() + sizeof<T0>()"),
-            ((pos_frst, 2, 0), "0"),
-            ((pos_scnd, 2, 0), "sizeof<R0>()"),
-            ((pos_frst, 2, 1), "0"),
-            ((pos_scnd, 2, 1), "sizeof<R0>()"),
-            ((pos_thrd, 2, 1), "sizeof<R0>() + sizeof<R1>()"),
-            ((pos_frst, 2, 2), "0"),
-            ((pos_scnd, 2, 2), "sizeof<R0>()"),
-            ((pos_thrd, 2, 2), "sizeof<R0>() + sizeof<R1>()"),
-            (
-                (pos_frth, 2, 2),
-                "sizeof<R0>() + sizeof<R1>() + sizeof<T0>()",
-            ),
-        ] {
-            assert_eq!(generics_offset(position, ret_count, arg_offset), expected);
-        }
-    }
-
-    #[test]
     fn generating_allocate_generic_instructions() {
         assert_eq!(
             generate_allocate_generic(0, 0),
             "
 @inline
 function allocate_ret_0_arg_0(): usize {
-    const to_allocate = 0; // constant folded
-    const stack_begin = stack_allocate(to_allocate); // inlined
+    const stack_begin = stack_allocate_values(0); // inlined
     return stack_begin;
 }"
         );
@@ -645,37 +590,29 @@ function allocate_ret_0_arg_0(): usize {
             "
 @inline
 function allocate_ret_0_arg_1<T0>(a0: T0): usize {
-    const to_allocate = sizeof<T0>(); // constant folded
-    const stack_begin = stack_allocate(to_allocate); // inlined
+    const stack_begin = stack_allocate_values(1); // inlined
     // store a0
-    const a0_offset = 0; // constant folded
-    wastrumentation_memory_store<T0>(stack_begin, a0, a0_offset); // inlined
+    wastrumentation_memory_store<T0>(stack_begin, a0, 0);
     return stack_begin;
 }"
         );
 
         assert_eq!(
         generate_allocate_generic(5, 5),
-        "
+"
 @inline
 function allocate_ret_5_arg_5<R0, R1, R2, R3, R4, T0, T1, T2, T3, T4>(a0: T0, a1: T1, a2: T2, a3: T3, a4: T4): usize {
-    const to_allocate = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>() + sizeof<R4>() + sizeof<T0>() + sizeof<T1>() + sizeof<T2>() + sizeof<T3>() + sizeof<T4>(); // constant folded
-    const stack_begin = stack_allocate(to_allocate); // inlined
+    const stack_begin = stack_allocate_values(10); // inlined
     // store a0
-    const a0_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>() + sizeof<R4>(); // constant folded
-    wastrumentation_memory_store<T0>(stack_begin, a0, a0_offset); // inlined
+    wastrumentation_memory_store<T0>(stack_begin, a0, 5);
     // store a1
-    const a1_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>() + sizeof<R4>() + sizeof<T0>(); // constant folded
-    wastrumentation_memory_store<T1>(stack_begin, a1, a1_offset); // inlined
+    wastrumentation_memory_store<T1>(stack_begin, a1, 6);
     // store a2
-    const a2_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>() + sizeof<R4>() + sizeof<T0>() + sizeof<T1>(); // constant folded
-    wastrumentation_memory_store<T2>(stack_begin, a2, a2_offset); // inlined
+    wastrumentation_memory_store<T2>(stack_begin, a2, 7);
     // store a3
-    const a3_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>() + sizeof<R4>() + sizeof<T0>() + sizeof<T1>() + sizeof<T2>(); // constant folded
-    wastrumentation_memory_store<T3>(stack_begin, a3, a3_offset); // inlined
+    wastrumentation_memory_store<T3>(stack_begin, a3, 8);
     // store a4
-    const a4_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>() + sizeof<R4>() + sizeof<T0>() + sizeof<T1>() + sizeof<T2>() + sizeof<T3>(); // constant folded
-    wastrumentation_memory_store<T4>(stack_begin, a4, a4_offset); // inlined
+    wastrumentation_memory_store<T4>(stack_begin, a4, 9);
     return stack_begin;
 }"
     );
@@ -706,70 +643,62 @@ export function allocate_ret_f64_f32_i32_i64_arg_i64_i32_f32_f64(a0: i64, a1: i3
             "
 @inline
 function load_arg0_ret_0_arg_1<T0>(stack_ptr: usize): T0 {
-    const a0_offset = 0; // constant folded
-    return wastrumentation_memory_load<T0>(stack_ptr, a0_offset); // inlined
+    return wastrumentation_memory_load<T0>(stack_ptr, 0);
 }",
         );
-        assert_eq!(generate_load_generic(5, 5), "
+        assert_eq!(
+            generate_load_generic(5, 5),
+            "
 @inline
 function load_arg0_ret_5_arg_5<R0, R1, R2, R3, R4, T0, T1, T2, T3, T4>(stack_ptr: usize): T0 {
-    const a0_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>() + sizeof<R4>(); // constant folded
-    return wastrumentation_memory_load<T0>(stack_ptr, a0_offset); // inlined
+    return wastrumentation_memory_load<T0>(stack_ptr, 5);
 }
 
 @inline
 function load_arg1_ret_5_arg_5<R0, R1, R2, R3, R4, T0, T1, T2, T3, T4>(stack_ptr: usize): T1 {
-    const a1_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>() + sizeof<R4>() + sizeof<T0>(); // constant folded
-    return wastrumentation_memory_load<T1>(stack_ptr, a1_offset); // inlined
+    return wastrumentation_memory_load<T1>(stack_ptr, 6);
 }
 
 @inline
 function load_arg2_ret_5_arg_5<R0, R1, R2, R3, R4, T0, T1, T2, T3, T4>(stack_ptr: usize): T2 {
-    const a2_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>() + sizeof<R4>() + sizeof<T0>() + sizeof<T1>(); // constant folded
-    return wastrumentation_memory_load<T2>(stack_ptr, a2_offset); // inlined
+    return wastrumentation_memory_load<T2>(stack_ptr, 7);
 }
 
 @inline
 function load_arg3_ret_5_arg_5<R0, R1, R2, R3, R4, T0, T1, T2, T3, T4>(stack_ptr: usize): T3 {
-    const a3_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>() + sizeof<R4>() + sizeof<T0>() + sizeof<T1>() + sizeof<T2>(); // constant folded
-    return wastrumentation_memory_load<T3>(stack_ptr, a3_offset); // inlined
+    return wastrumentation_memory_load<T3>(stack_ptr, 8);
 }
 
 @inline
 function load_arg4_ret_5_arg_5<R0, R1, R2, R3, R4, T0, T1, T2, T3, T4>(stack_ptr: usize): T4 {
-    const a4_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>() + sizeof<R4>() + sizeof<T0>() + sizeof<T1>() + sizeof<T2>() + sizeof<T3>(); // constant folded
-    return wastrumentation_memory_load<T4>(stack_ptr, a4_offset); // inlined
+    return wastrumentation_memory_load<T4>(stack_ptr, 9);
 }
 
 @inline
 function load_ret0_ret_5_arg_5<R0, R1, R2, R3, R4, T0, T1, T2, T3, T4>(stack_ptr: usize): R0 {
-    const r0_offset = 0; // constant folded
-    return wastrumentation_memory_load<R0>(stack_ptr, r0_offset); // inlined
+    return wastrumentation_memory_load<R0>(stack_ptr, 0);
 }
 
 @inline
 function load_ret1_ret_5_arg_5<R0, R1, R2, R3, R4, T0, T1, T2, T3, T4>(stack_ptr: usize): R1 {
-    const r1_offset = sizeof<R0>(); // constant folded
-    return wastrumentation_memory_load<R1>(stack_ptr, r1_offset); // inlined
+    return wastrumentation_memory_load<R1>(stack_ptr, 1);
 }
 
 @inline
 function load_ret2_ret_5_arg_5<R0, R1, R2, R3, R4, T0, T1, T2, T3, T4>(stack_ptr: usize): R2 {
-    const r2_offset = sizeof<R0>() + sizeof<R1>(); // constant folded
-    return wastrumentation_memory_load<R2>(stack_ptr, r2_offset); // inlined
+    return wastrumentation_memory_load<R2>(stack_ptr, 2);
 }
 
 @inline
 function load_ret3_ret_5_arg_5<R0, R1, R2, R3, R4, T0, T1, T2, T3, T4>(stack_ptr: usize): R3 {
-    const r3_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>(); // constant folded
-    return wastrumentation_memory_load<R3>(stack_ptr, r3_offset); // inlined
+    return wastrumentation_memory_load<R3>(stack_ptr, 3);
 }
 
 @inline
 function load_ret4_ret_5_arg_5<R0, R1, R2, R3, R4, T0, T1, T2, T3, T4>(stack_ptr: usize): R4 {
-    const r4_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>(); // constant folded
-    return wastrumentation_memory_load<R4>(stack_ptr, r4_offset); // inlined
-}");
+    return wastrumentation_memory_load<R4>(stack_ptr, 4);
+}"
+        );
     }
 
     #[test]
@@ -840,69 +769,58 @@ export function load_ret3_ret_f64_f32_i32_i64_arg_i64_i32_f32_f64(stack_ptr: usi
             "
 @inline
 function store_arg0_ret_0_arg_1<T0>(stack_ptr: usize, a0: T0): void {
-    const a0_offset = 0; // constant folded
-    return wastrumentation_memory_store<T0>(stack_ptr, a0, a0_offset); // inlined
-}",
+    return wastrumentation_memory_store<T0>(stack_ptr, a0, 0);
+}"
         );
         assert_eq!(generate_store_generic(5, 5), "
 @inline
 function store_arg0_ret_5_arg_5<R0, R1, R2, R3, R4, T0, T1, T2, T3, T4>(stack_ptr: usize, a0: T0): void {
-    const a0_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>() + sizeof<R4>(); // constant folded
-    return wastrumentation_memory_store<T0>(stack_ptr, a0, a0_offset); // inlined
+    return wastrumentation_memory_store<T0>(stack_ptr, a0, 5);
 }
 
 @inline
 function store_arg1_ret_5_arg_5<R0, R1, R2, R3, R4, T0, T1, T2, T3, T4>(stack_ptr: usize, a1: T1): void {
-    const a1_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>() + sizeof<R4>() + sizeof<T0>(); // constant folded
-    return wastrumentation_memory_store<T1>(stack_ptr, a1, a1_offset); // inlined
+    return wastrumentation_memory_store<T1>(stack_ptr, a1, 6);
 }
 
 @inline
 function store_arg2_ret_5_arg_5<R0, R1, R2, R3, R4, T0, T1, T2, T3, T4>(stack_ptr: usize, a2: T2): void {
-    const a2_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>() + sizeof<R4>() + sizeof<T0>() + sizeof<T1>(); // constant folded
-    return wastrumentation_memory_store<T2>(stack_ptr, a2, a2_offset); // inlined
+    return wastrumentation_memory_store<T2>(stack_ptr, a2, 7);
 }
 
 @inline
 function store_arg3_ret_5_arg_5<R0, R1, R2, R3, R4, T0, T1, T2, T3, T4>(stack_ptr: usize, a3: T3): void {
-    const a3_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>() + sizeof<R4>() + sizeof<T0>() + sizeof<T1>() + sizeof<T2>(); // constant folded
-    return wastrumentation_memory_store<T3>(stack_ptr, a3, a3_offset); // inlined
+    return wastrumentation_memory_store<T3>(stack_ptr, a3, 8);
 }
 
 @inline
 function store_arg4_ret_5_arg_5<R0, R1, R2, R3, R4, T0, T1, T2, T3, T4>(stack_ptr: usize, a4: T4): void {
-    const a4_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>() + sizeof<R4>() + sizeof<T0>() + sizeof<T1>() + sizeof<T2>() + sizeof<T3>(); // constant folded
-    return wastrumentation_memory_store<T4>(stack_ptr, a4, a4_offset); // inlined
+    return wastrumentation_memory_store<T4>(stack_ptr, a4, 9);
 }
 
 @inline
 function store_ret0_ret_5_arg_5<R0, R1, R2, R3, R4, T0, T1, T2, T3, T4>(stack_ptr: usize, r0: R0): void {
-    const r0_offset = 0; // constant folded
-    return wastrumentation_memory_store<R0>(stack_ptr, r0, r0_offset); // inlined
+    return wastrumentation_memory_store<R0>(stack_ptr, r0, 0);
 }
 
 @inline
 function store_ret1_ret_5_arg_5<R0, R1, R2, R3, R4, T0, T1, T2, T3, T4>(stack_ptr: usize, r1: R1): void {
-    const r1_offset = sizeof<R0>(); // constant folded
-    return wastrumentation_memory_store<R1>(stack_ptr, r1, r1_offset); // inlined
+    return wastrumentation_memory_store<R1>(stack_ptr, r1, 1);
 }
 
 @inline
 function store_ret2_ret_5_arg_5<R0, R1, R2, R3, R4, T0, T1, T2, T3, T4>(stack_ptr: usize, r2: R2): void {
-    const r2_offset = sizeof<R0>() + sizeof<R1>(); // constant folded
-    return wastrumentation_memory_store<R2>(stack_ptr, r2, r2_offset); // inlined
+    return wastrumentation_memory_store<R2>(stack_ptr, r2, 2);
 }
 
 @inline
 function store_ret3_ret_5_arg_5<R0, R1, R2, R3, R4, T0, T1, T2, T3, T4>(stack_ptr: usize, r3: R3): void {
-    const r3_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>(); // constant folded
-    return wastrumentation_memory_store<R3>(stack_ptr, r3, r3_offset); // inlined
+    return wastrumentation_memory_store<R3>(stack_ptr, r3, 3);
 }
 
 @inline
 function store_ret4_ret_5_arg_5<R0, R1, R2, R3, R4, T0, T1, T2, T3, T4>(stack_ptr: usize, r4: R4): void {
-    const r4_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>(); // constant folded
-    return wastrumentation_memory_store<R4>(stack_ptr, r4, r4_offset); // inlined
+    return wastrumentation_memory_store<R4>(stack_ptr, r4, 4);
 }");
     }
 
@@ -969,18 +887,19 @@ export function store_ret3_ret_f64_f32_i32_i64_arg_i64_i32_f32_f64(stack_ptr: us
             "
 @inline
 function free_values_ret_0_arg_1<T0>(ptr: usize): void {
-    const to_deallocate = sizeof<T0>(); // constant folded
-    stack_deallocate(ptr, to_deallocate); // inlined
+    stack_deallocate_values(ptr, 1); // inlined
     return;
 }"
         );
-        assert_eq!(generate_free_values_buffer_generic(5, 5), "
+        assert_eq!(
+            generate_free_values_buffer_generic(5, 5),
+            "
 @inline
 function free_values_ret_5_arg_5<R0, R1, R2, R3, R4, T0, T1, T2, T3, T4>(ptr: usize): void {
-    const to_deallocate = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>() + sizeof<R4>() + sizeof<T0>() + sizeof<T1>() + sizeof<T2>() + sizeof<T3>() + sizeof<T4>(); // constant folded
-    stack_deallocate(ptr, to_deallocate); // inlined
+    stack_deallocate_values(ptr, 10); // inlined
     return;
-}");
+}"
+        );
     }
 
     #[test]
@@ -1011,8 +930,7 @@ export function free_values_ret_f64_f32_i32_i64_arg_i64_i32_f32_f64(ptr: usize):
             "
 @inline
 function free_types_ret_0_arg_1(ptr: usize): void {
-    const to_deallocate = sizeof<i32>() * 1;; // constant folded
-    stack_deallocate(ptr, to_deallocate); // inlined
+    stack_deallocate_types(ptr, 1); // inlined
     return;
 }"
         );
@@ -1021,8 +939,7 @@ function free_types_ret_0_arg_1(ptr: usize): void {
             "
 @inline
 function free_types_ret_5_arg_5(ptr: usize): void {
-    const to_deallocate = sizeof<i32>() * 10;; // constant folded
-    stack_deallocate(ptr, to_deallocate); // inlined
+    stack_deallocate_types(ptr, 10); // inlined
     return;
 }"
         );
@@ -1098,8 +1015,7 @@ export function store_rets_ret_f64_f32_i32_i64_arg_i64_i32_f32_f64(stack_ptr: us
             "
 @inline
 function allocate_signature_types_buffer_ret_0_arg_1(): usize {
-    const to_allocate = sizeof<i32>() * 1;; // constant folded
-    const stack_begin = stack_allocate(to_allocate); // inlined
+    const stack_begin = stack_allocate_types(1); // inlined
     return stack_begin;
 }"
         );
@@ -1109,8 +1025,7 @@ function allocate_signature_types_buffer_ret_0_arg_1(): usize {
             "
 @inline
 function allocate_signature_types_buffer_ret_5_arg_5(): usize {
-    const to_allocate = sizeof<i32>() * 10;; // constant folded
-    const stack_begin = stack_allocate(to_allocate); // inlined
+    const stack_begin = stack_allocate_types(10); // inlined
     return stack_begin;
 }"
         )
@@ -1139,10 +1054,10 @@ export function allocate_types_ret_arg(): usize {
             "
 export function allocate_types_ret_f64_f32_arg_i32_i64(): usize {
     const types_buffer = allocate_signature_types_buffer_ret_2_arg_2();
-    wastrumentation_memory_store<i32>(types_buffer, 3, (sizeof<i32>()*0));
-    wastrumentation_memory_store<i32>(types_buffer, 1, (sizeof<i32>()*1));
-    wastrumentation_memory_store<i32>(types_buffer, 0, (sizeof<i32>()*2));
-    wastrumentation_memory_store<i32>(types_buffer, 2, (sizeof<i32>()*3));
+    wastrumentation_stack_store_type(types_buffer, 0, 3);
+    wastrumentation_stack_store_type(types_buffer, 1, 1);
+    wastrumentation_stack_store_type(types_buffer, 2, 0);
+    wastrumentation_stack_store_type(types_buffer, 3, 2);
     return types_buffer;
 }"
         );
@@ -1155,14 +1070,14 @@ export function allocate_types_ret_f64_f32_arg_i32_i64(): usize {
             "
 export function allocate_types_ret_f64_f32_i32_i64_arg_i64_i32_f32_f64(): usize {
     const types_buffer = allocate_signature_types_buffer_ret_4_arg_4();
-    wastrumentation_memory_store<i32>(types_buffer, 3, (sizeof<i32>()*0));
-    wastrumentation_memory_store<i32>(types_buffer, 1, (sizeof<i32>()*1));
-    wastrumentation_memory_store<i32>(types_buffer, 0, (sizeof<i32>()*2));
-    wastrumentation_memory_store<i32>(types_buffer, 2, (sizeof<i32>()*3));
-    wastrumentation_memory_store<i32>(types_buffer, 2, (sizeof<i32>()*4));
-    wastrumentation_memory_store<i32>(types_buffer, 0, (sizeof<i32>()*5));
-    wastrumentation_memory_store<i32>(types_buffer, 1, (sizeof<i32>()*6));
-    wastrumentation_memory_store<i32>(types_buffer, 3, (sizeof<i32>()*7));
+    wastrumentation_stack_store_type(types_buffer, 0, 3);
+    wastrumentation_stack_store_type(types_buffer, 1, 1);
+    wastrumentation_stack_store_type(types_buffer, 2, 0);
+    wastrumentation_stack_store_type(types_buffer, 3, 2);
+    wastrumentation_stack_store_type(types_buffer, 4, 2);
+    wastrumentation_stack_store_type(types_buffer, 5, 0);
+    wastrumentation_stack_store_type(types_buffer, 6, 1);
+    wastrumentation_stack_store_type(types_buffer, 7, 3);
     return types_buffer;
 }"
         );
@@ -1182,10 +1097,10 @@ export function allocate_types_ret_f64_f32_i32_i64_arg_i64_i32_f32_f64(): usize 
             "
 export function allocate_types_ret_ref_func_ref_func_arg_ref_extern_ref_extern(): usize {
     const types_buffer = allocate_signature_types_buffer_ret_2_arg_2();
-    wastrumentation_memory_store<i32>(types_buffer, 4, (sizeof<i32>()*0));
-    wastrumentation_memory_store<i32>(types_buffer, 4, (sizeof<i32>()*1));
-    wastrumentation_memory_store<i32>(types_buffer, 5, (sizeof<i32>()*2));
-    wastrumentation_memory_store<i32>(types_buffer, 5, (sizeof<i32>()*3));
+    wastrumentation_stack_store_type(types_buffer, 0, 4);
+    wastrumentation_stack_store_type(types_buffer, 1, 4);
+    wastrumentation_stack_store_type(types_buffer, 2, 5);
+    wastrumentation_stack_store_type(types_buffer, 3, 5);
     return types_buffer;
 }"
         );

--- a/wastrumentation-instr-lib/src/lib_gen/instrumentation/assemblyscript/test/expected_lib.ts
+++ b/wastrumentation-instr-lib/src/lib_gen/instrumentation/assemblyscript/test/expected_lib.ts
@@ -1,14 +1,12 @@
 
 @inline
 function allocate_ret_0_arg_0(): usize {
-    const to_allocate = 0; // constant folded
-    const stack_begin = stack_allocate(to_allocate); // inlined
+    const stack_begin = stack_allocate_values(0); // inlined
     return stack_begin;
 }
 @inline
 function free_values_ret_0_arg_0(ptr: usize): void {
-    const to_deallocate = 0; // constant folded
-    stack_deallocate(ptr, to_deallocate); // inlined
+    stack_deallocate_values(ptr, 0); // inlined
     return;
 }
 @inline
@@ -17,14 +15,12 @@ function store_rets_ret_0_arg_0(stack_ptr: usize): void {
 }
 @inline
 function allocate_signature_types_buffer_ret_0_arg_0(): usize {
-    const to_allocate = sizeof<i32>() * 0;; // constant folded
-    const stack_begin = stack_allocate(to_allocate); // inlined
+    const stack_begin = stack_allocate_types(0); // inlined
     return stack_begin;
 }
 @inline
 function free_types_ret_0_arg_0(ptr: usize): void {
-    const to_deallocate = sizeof<i32>() * 0;; // constant folded
-    stack_deallocate(ptr, to_deallocate); // inlined
+    stack_deallocate_types(ptr, 0); // inlined
     return;
 }
 export function allocate_ret_arg(): usize {
@@ -46,66 +42,54 @@ export function free_types_ret_arg(ptr: usize): void {
 };
 @inline
 function allocate_ret_2_arg_2<R0, R1, T0, T1>(a0: T0, a1: T1): usize {
-    const to_allocate = sizeof<R0>() + sizeof<R1>() + sizeof<T0>() + sizeof<T1>(); // constant folded
-    const stack_begin = stack_allocate(to_allocate); // inlined
+    const stack_begin = stack_allocate_values(4); // inlined
     // store a0
-    const a0_offset = sizeof<R0>() + sizeof<R1>(); // constant folded
-    wastrumentation_memory_store<T0>(stack_begin, a0, a0_offset); // inlined
+    wastrumentation_memory_store<T0>(stack_begin, a0, 2);
     // store a1
-    const a1_offset = sizeof<R0>() + sizeof<R1>() + sizeof<T0>(); // constant folded
-    wastrumentation_memory_store<T1>(stack_begin, a1, a1_offset); // inlined
+    wastrumentation_memory_store<T1>(stack_begin, a1, 3);
     return stack_begin;
 }
 @inline
 function load_arg0_ret_2_arg_2<R0, R1, T0, T1>(stack_ptr: usize): T0 {
-    const a0_offset = sizeof<R0>() + sizeof<R1>(); // constant folded
-    return wastrumentation_memory_load<T0>(stack_ptr, a0_offset); // inlined
+    return wastrumentation_memory_load<T0>(stack_ptr, 2);
 }
 
 @inline
 function load_arg1_ret_2_arg_2<R0, R1, T0, T1>(stack_ptr: usize): T1 {
-    const a1_offset = sizeof<R0>() + sizeof<R1>() + sizeof<T0>(); // constant folded
-    return wastrumentation_memory_load<T1>(stack_ptr, a1_offset); // inlined
+    return wastrumentation_memory_load<T1>(stack_ptr, 3);
 }
 
 @inline
 function load_ret0_ret_2_arg_2<R0, R1, T0, T1>(stack_ptr: usize): R0 {
-    const r0_offset = 0; // constant folded
-    return wastrumentation_memory_load<R0>(stack_ptr, r0_offset); // inlined
+    return wastrumentation_memory_load<R0>(stack_ptr, 0);
 }
 
 @inline
 function load_ret1_ret_2_arg_2<R0, R1, T0, T1>(stack_ptr: usize): R1 {
-    const r1_offset = sizeof<R0>(); // constant folded
-    return wastrumentation_memory_load<R1>(stack_ptr, r1_offset); // inlined
+    return wastrumentation_memory_load<R1>(stack_ptr, 1);
 }
 @inline
 function store_arg0_ret_2_arg_2<R0, R1, T0, T1>(stack_ptr: usize, a0: T0): void {
-    const a0_offset = sizeof<R0>() + sizeof<R1>(); // constant folded
-    return wastrumentation_memory_store<T0>(stack_ptr, a0, a0_offset); // inlined
+    return wastrumentation_memory_store<T0>(stack_ptr, a0, 2);
 }
 
 @inline
 function store_arg1_ret_2_arg_2<R0, R1, T0, T1>(stack_ptr: usize, a1: T1): void {
-    const a1_offset = sizeof<R0>() + sizeof<R1>() + sizeof<T0>(); // constant folded
-    return wastrumentation_memory_store<T1>(stack_ptr, a1, a1_offset); // inlined
+    return wastrumentation_memory_store<T1>(stack_ptr, a1, 3);
 }
 
 @inline
 function store_ret0_ret_2_arg_2<R0, R1, T0, T1>(stack_ptr: usize, r0: R0): void {
-    const r0_offset = 0; // constant folded
-    return wastrumentation_memory_store<R0>(stack_ptr, r0, r0_offset); // inlined
+    return wastrumentation_memory_store<R0>(stack_ptr, r0, 0);
 }
 
 @inline
 function store_ret1_ret_2_arg_2<R0, R1, T0, T1>(stack_ptr: usize, r1: R1): void {
-    const r1_offset = sizeof<R0>(); // constant folded
-    return wastrumentation_memory_store<R1>(stack_ptr, r1, r1_offset); // inlined
+    return wastrumentation_memory_store<R1>(stack_ptr, r1, 1);
 }
 @inline
 function free_values_ret_2_arg_2<R0, R1, T0, T1>(ptr: usize): void {
-    const to_deallocate = sizeof<R0>() + sizeof<R1>() + sizeof<T0>() + sizeof<T1>(); // constant folded
-    stack_deallocate(ptr, to_deallocate); // inlined
+    stack_deallocate_values(ptr, 4); // inlined
     return;
 }
 @inline
@@ -118,14 +102,12 @@ function store_rets_ret_2_arg_2<R0, R1, T0, T1>(stack_ptr: usize, a0: R0, a1: R1
 }
 @inline
 function allocate_signature_types_buffer_ret_2_arg_2(): usize {
-    const to_allocate = sizeof<i32>() * 4;; // constant folded
-    const stack_begin = stack_allocate(to_allocate); // inlined
+    const stack_begin = stack_allocate_types(4); // inlined
     return stack_begin;
 }
 @inline
 function free_types_ret_2_arg_2(ptr: usize): void {
-    const to_deallocate = sizeof<i32>() * 4;; // constant folded
-    stack_deallocate(ptr, to_deallocate); // inlined
+    stack_deallocate_types(ptr, 4); // inlined
     return;
 }
 export function allocate_ret_f32_f64_arg_i32_i64(a0: i32, a1: i64): usize {
@@ -170,10 +152,10 @@ export function store_rets_ret_f32_f64_arg_i32_i64(stack_ptr: usize, a0: f32, a1
 };
 export function allocate_types_ret_f32_f64_arg_i32_i64(): usize {
     const types_buffer = allocate_signature_types_buffer_ret_2_arg_2();
-    wastrumentation_memory_store<i32>(types_buffer, 1, (sizeof<i32>()*0));
-    wastrumentation_memory_store<i32>(types_buffer, 3, (sizeof<i32>()*1));
-    wastrumentation_memory_store<i32>(types_buffer, 0, (sizeof<i32>()*2));
-    wastrumentation_memory_store<i32>(types_buffer, 2, (sizeof<i32>()*3));
+    wastrumentation_stack_store_type(types_buffer, 0, 1);
+    wastrumentation_stack_store_type(types_buffer, 1, 3);
+    wastrumentation_stack_store_type(types_buffer, 2, 0);
+    wastrumentation_stack_store_type(types_buffer, 3, 2);
     return types_buffer;
 }
 export function free_types_ret_f32_f64_arg_i32_i64(ptr: usize): void {
@@ -221,10 +203,10 @@ export function store_rets_ret_f64_f32_arg_i32_i64(stack_ptr: usize, a0: f64, a1
 };
 export function allocate_types_ret_f64_f32_arg_i32_i64(): usize {
     const types_buffer = allocate_signature_types_buffer_ret_2_arg_2();
-    wastrumentation_memory_store<i32>(types_buffer, 3, (sizeof<i32>()*0));
-    wastrumentation_memory_store<i32>(types_buffer, 1, (sizeof<i32>()*1));
-    wastrumentation_memory_store<i32>(types_buffer, 0, (sizeof<i32>()*2));
-    wastrumentation_memory_store<i32>(types_buffer, 2, (sizeof<i32>()*3));
+    wastrumentation_stack_store_type(types_buffer, 0, 3);
+    wastrumentation_stack_store_type(types_buffer, 1, 1);
+    wastrumentation_stack_store_type(types_buffer, 2, 0);
+    wastrumentation_stack_store_type(types_buffer, 3, 2);
     return types_buffer;
 }
 export function free_types_ret_f64_f32_arg_i32_i64(ptr: usize): void {
@@ -232,120 +214,98 @@ export function free_types_ret_f64_f32_arg_i32_i64(ptr: usize): void {
 };
 @inline
 function allocate_ret_4_arg_4<R0, R1, R2, R3, T0, T1, T2, T3>(a0: T0, a1: T1, a2: T2, a3: T3): usize {
-    const to_allocate = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>() + sizeof<T0>() + sizeof<T1>() + sizeof<T2>() + sizeof<T3>(); // constant folded
-    const stack_begin = stack_allocate(to_allocate); // inlined
+    const stack_begin = stack_allocate_values(8); // inlined
     // store a0
-    const a0_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>(); // constant folded
-    wastrumentation_memory_store<T0>(stack_begin, a0, a0_offset); // inlined
+    wastrumentation_memory_store<T0>(stack_begin, a0, 4);
     // store a1
-    const a1_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>() + sizeof<T0>(); // constant folded
-    wastrumentation_memory_store<T1>(stack_begin, a1, a1_offset); // inlined
+    wastrumentation_memory_store<T1>(stack_begin, a1, 5);
     // store a2
-    const a2_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>() + sizeof<T0>() + sizeof<T1>(); // constant folded
-    wastrumentation_memory_store<T2>(stack_begin, a2, a2_offset); // inlined
+    wastrumentation_memory_store<T2>(stack_begin, a2, 6);
     // store a3
-    const a3_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>() + sizeof<T0>() + sizeof<T1>() + sizeof<T2>(); // constant folded
-    wastrumentation_memory_store<T3>(stack_begin, a3, a3_offset); // inlined
+    wastrumentation_memory_store<T3>(stack_begin, a3, 7);
     return stack_begin;
 }
 @inline
 function load_arg0_ret_4_arg_4<R0, R1, R2, R3, T0, T1, T2, T3>(stack_ptr: usize): T0 {
-    const a0_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>(); // constant folded
-    return wastrumentation_memory_load<T0>(stack_ptr, a0_offset); // inlined
+    return wastrumentation_memory_load<T0>(stack_ptr, 4);
 }
 
 @inline
 function load_arg1_ret_4_arg_4<R0, R1, R2, R3, T0, T1, T2, T3>(stack_ptr: usize): T1 {
-    const a1_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>() + sizeof<T0>(); // constant folded
-    return wastrumentation_memory_load<T1>(stack_ptr, a1_offset); // inlined
+    return wastrumentation_memory_load<T1>(stack_ptr, 5);
 }
 
 @inline
 function load_arg2_ret_4_arg_4<R0, R1, R2, R3, T0, T1, T2, T3>(stack_ptr: usize): T2 {
-    const a2_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>() + sizeof<T0>() + sizeof<T1>(); // constant folded
-    return wastrumentation_memory_load<T2>(stack_ptr, a2_offset); // inlined
+    return wastrumentation_memory_load<T2>(stack_ptr, 6);
 }
 
 @inline
 function load_arg3_ret_4_arg_4<R0, R1, R2, R3, T0, T1, T2, T3>(stack_ptr: usize): T3 {
-    const a3_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>() + sizeof<T0>() + sizeof<T1>() + sizeof<T2>(); // constant folded
-    return wastrumentation_memory_load<T3>(stack_ptr, a3_offset); // inlined
+    return wastrumentation_memory_load<T3>(stack_ptr, 7);
 }
 
 @inline
 function load_ret0_ret_4_arg_4<R0, R1, R2, R3, T0, T1, T2, T3>(stack_ptr: usize): R0 {
-    const r0_offset = 0; // constant folded
-    return wastrumentation_memory_load<R0>(stack_ptr, r0_offset); // inlined
+    return wastrumentation_memory_load<R0>(stack_ptr, 0);
 }
 
 @inline
 function load_ret1_ret_4_arg_4<R0, R1, R2, R3, T0, T1, T2, T3>(stack_ptr: usize): R1 {
-    const r1_offset = sizeof<R0>(); // constant folded
-    return wastrumentation_memory_load<R1>(stack_ptr, r1_offset); // inlined
+    return wastrumentation_memory_load<R1>(stack_ptr, 1);
 }
 
 @inline
 function load_ret2_ret_4_arg_4<R0, R1, R2, R3, T0, T1, T2, T3>(stack_ptr: usize): R2 {
-    const r2_offset = sizeof<R0>() + sizeof<R1>(); // constant folded
-    return wastrumentation_memory_load<R2>(stack_ptr, r2_offset); // inlined
+    return wastrumentation_memory_load<R2>(stack_ptr, 2);
 }
 
 @inline
 function load_ret3_ret_4_arg_4<R0, R1, R2, R3, T0, T1, T2, T3>(stack_ptr: usize): R3 {
-    const r3_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>(); // constant folded
-    return wastrumentation_memory_load<R3>(stack_ptr, r3_offset); // inlined
+    return wastrumentation_memory_load<R3>(stack_ptr, 3);
 }
 @inline
 function store_arg0_ret_4_arg_4<R0, R1, R2, R3, T0, T1, T2, T3>(stack_ptr: usize, a0: T0): void {
-    const a0_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>(); // constant folded
-    return wastrumentation_memory_store<T0>(stack_ptr, a0, a0_offset); // inlined
+    return wastrumentation_memory_store<T0>(stack_ptr, a0, 4);
 }
 
 @inline
 function store_arg1_ret_4_arg_4<R0, R1, R2, R3, T0, T1, T2, T3>(stack_ptr: usize, a1: T1): void {
-    const a1_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>() + sizeof<T0>(); // constant folded
-    return wastrumentation_memory_store<T1>(stack_ptr, a1, a1_offset); // inlined
+    return wastrumentation_memory_store<T1>(stack_ptr, a1, 5);
 }
 
 @inline
 function store_arg2_ret_4_arg_4<R0, R1, R2, R3, T0, T1, T2, T3>(stack_ptr: usize, a2: T2): void {
-    const a2_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>() + sizeof<T0>() + sizeof<T1>(); // constant folded
-    return wastrumentation_memory_store<T2>(stack_ptr, a2, a2_offset); // inlined
+    return wastrumentation_memory_store<T2>(stack_ptr, a2, 6);
 }
 
 @inline
 function store_arg3_ret_4_arg_4<R0, R1, R2, R3, T0, T1, T2, T3>(stack_ptr: usize, a3: T3): void {
-    const a3_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>() + sizeof<T0>() + sizeof<T1>() + sizeof<T2>(); // constant folded
-    return wastrumentation_memory_store<T3>(stack_ptr, a3, a3_offset); // inlined
+    return wastrumentation_memory_store<T3>(stack_ptr, a3, 7);
 }
 
 @inline
 function store_ret0_ret_4_arg_4<R0, R1, R2, R3, T0, T1, T2, T3>(stack_ptr: usize, r0: R0): void {
-    const r0_offset = 0; // constant folded
-    return wastrumentation_memory_store<R0>(stack_ptr, r0, r0_offset); // inlined
+    return wastrumentation_memory_store<R0>(stack_ptr, r0, 0);
 }
 
 @inline
 function store_ret1_ret_4_arg_4<R0, R1, R2, R3, T0, T1, T2, T3>(stack_ptr: usize, r1: R1): void {
-    const r1_offset = sizeof<R0>(); // constant folded
-    return wastrumentation_memory_store<R1>(stack_ptr, r1, r1_offset); // inlined
+    return wastrumentation_memory_store<R1>(stack_ptr, r1, 1);
 }
 
 @inline
 function store_ret2_ret_4_arg_4<R0, R1, R2, R3, T0, T1, T2, T3>(stack_ptr: usize, r2: R2): void {
-    const r2_offset = sizeof<R0>() + sizeof<R1>(); // constant folded
-    return wastrumentation_memory_store<R2>(stack_ptr, r2, r2_offset); // inlined
+    return wastrumentation_memory_store<R2>(stack_ptr, r2, 2);
 }
 
 @inline
 function store_ret3_ret_4_arg_4<R0, R1, R2, R3, T0, T1, T2, T3>(stack_ptr: usize, r3: R3): void {
-    const r3_offset = sizeof<R0>() + sizeof<R1>() + sizeof<R2>(); // constant folded
-    return wastrumentation_memory_store<R3>(stack_ptr, r3, r3_offset); // inlined
+    return wastrumentation_memory_store<R3>(stack_ptr, r3, 3);
 }
 @inline
 function free_values_ret_4_arg_4<R0, R1, R2, R3, T0, T1, T2, T3>(ptr: usize): void {
-    const to_deallocate = sizeof<R0>() + sizeof<R1>() + sizeof<R2>() + sizeof<R3>() + sizeof<T0>() + sizeof<T1>() + sizeof<T2>() + sizeof<T3>(); // constant folded
-    stack_deallocate(ptr, to_deallocate); // inlined
+    stack_deallocate_values(ptr, 8); // inlined
     return;
 }
 @inline
@@ -362,14 +322,12 @@ function store_rets_ret_4_arg_4<R0, R1, R2, R3, T0, T1, T2, T3>(stack_ptr: usize
 }
 @inline
 function allocate_signature_types_buffer_ret_4_arg_4(): usize {
-    const to_allocate = sizeof<i32>() * 8;; // constant folded
-    const stack_begin = stack_allocate(to_allocate); // inlined
+    const stack_begin = stack_allocate_types(8); // inlined
     return stack_begin;
 }
 @inline
 function free_types_ret_4_arg_4(ptr: usize): void {
-    const to_deallocate = sizeof<i32>() * 8;; // constant folded
-    stack_deallocate(ptr, to_deallocate); // inlined
+    stack_deallocate_types(ptr, 8); // inlined
     return;
 }
 export function allocate_ret_f64_f32_i32_i64_arg_i64_i32_f32_f64(a0: i64, a1: i32, a2: f32, a3: f64): usize {
@@ -446,14 +404,14 @@ export function store_rets_ret_f64_f32_i32_i64_arg_i64_i32_f32_f64(stack_ptr: us
 };
 export function allocate_types_ret_f64_f32_i32_i64_arg_i64_i32_f32_f64(): usize {
     const types_buffer = allocate_signature_types_buffer_ret_4_arg_4();
-    wastrumentation_memory_store<i32>(types_buffer, 3, (sizeof<i32>()*0));
-    wastrumentation_memory_store<i32>(types_buffer, 1, (sizeof<i32>()*1));
-    wastrumentation_memory_store<i32>(types_buffer, 0, (sizeof<i32>()*2));
-    wastrumentation_memory_store<i32>(types_buffer, 2, (sizeof<i32>()*3));
-    wastrumentation_memory_store<i32>(types_buffer, 2, (sizeof<i32>()*4));
-    wastrumentation_memory_store<i32>(types_buffer, 0, (sizeof<i32>()*5));
-    wastrumentation_memory_store<i32>(types_buffer, 1, (sizeof<i32>()*6));
-    wastrumentation_memory_store<i32>(types_buffer, 3, (sizeof<i32>()*7));
+    wastrumentation_stack_store_type(types_buffer, 0, 3);
+    wastrumentation_stack_store_type(types_buffer, 1, 1);
+    wastrumentation_stack_store_type(types_buffer, 2, 0);
+    wastrumentation_stack_store_type(types_buffer, 3, 2);
+    wastrumentation_stack_store_type(types_buffer, 4, 2);
+    wastrumentation_stack_store_type(types_buffer, 5, 0);
+    wastrumentation_stack_store_type(types_buffer, 6, 1);
+    wastrumentation_stack_store_type(types_buffer, 7, 3);
     return types_buffer;
 }
 export function free_types_ret_f64_f32_i32_i64_arg_i64_i32_f32_f64(ptr: usize): void {

--- a/wastrumentation-instr-lib/src/lib_gen/instrumentation/rust/default_manifest_source.toml
+++ b/wastrumentation-instr-lib/src/lib_gen/instrumentation/rust/default_manifest_source.toml
@@ -6,4 +6,5 @@ dependencies.wee_alloc = "0.4.5"
 profile.release.strip = true
 profile.release.lto = true
 profile.release.panic = "abort"
+profile.dev.panic = "abort"
 [workspace]

--- a/wastrumentation-instr-lib/src/lib_gen/instrumentation/rust/mod.rs
+++ b/wastrumentation-instr-lib/src/lib_gen/instrumentation/rust/mod.rs
@@ -3,6 +3,7 @@ use std::{collections::HashSet, marker::PhantomData, ops::Deref, vec};
 use crate::lib_compile::rust::options::{ManifestSource, RustSource, RustSourceCode};
 use crate::lib_compile::rust::Rust;
 use rust_to_wasm_compiler::WasiSupport;
+use wastrumentation::wasm_constructs::RefType;
 use wastrumentation::{
     compiler::{LibGeneratable, Library},
     wasm_constructs::{Signature, SignatureSide, WasmType},
@@ -10,18 +11,6 @@ use wastrumentation::{
 
 #[cfg(test)]
 mod tests;
-
-// TODO: since this holds:
-
-// fn foo() {
-//     let tuple_size = size_of::<(f64, i32, i32)>();
-//     let sum_size = size_of::<f64>() + size_of::<i32>() + size_of::<i32>();
-//     assert_eq!(tuple_size, sum_size)
-// }
-
-// => WARNING: Due to alignment, some structures are padded. As such, size_of::<struct _X(i32,u8)>() != size_of::<(i32,u8)>() ...
-
-// I could move all "+" expressions to a tuple variant ... Should not change anything, but 'enforce' constant folding
 
 impl LibGeneratable for Rust {
     fn generate_lib(signatures: &[Signature]) -> Library<Self> {
@@ -56,151 +45,69 @@ impl RustSignature<'_> {
         format!("ret_{signature_rets_count}_arg_{signature_args_count}")
     }
 
-    fn generic_rust_where_clause(rets_count: usize, args_count: usize) -> String {
-        if rets_count + args_count == 0 {
-            String::new()
-        } else {
-            format!(
-                "where {}",
-                Self::rust_generics(rets_count, args_count)
-                    .into_iter()
-                    .map(|t| format!("{t}: Copy"))
-                    .collect::<Vec<String>>()
-                    .join(", ")
-            )
+    fn wasmvalue_constructor_for_type(wasm_type: &WasmType) -> String {
+        match wasm_type {
+            WasmType::I32 => "WasmValue::new_i32".to_string(),
+            WasmType::F32 => "WasmValue::new_f32".to_string(),
+            WasmType::I64 => "WasmValue::new_i64".to_string(),
+            WasmType::F64 => "WasmValue::new_f64".to_string(),
+            WasmType::Ref(RefType::ExternRef) => "WasmValue::new_extern_ref".to_string(),
+            WasmType::Ref(RefType::FuncRef) => "WasmValue::new_func_ref".to_string(),
         }
     }
 
-    fn rust_comma_separated_types(&self) -> String {
-        if self.is_empty() {
-            String::new()
-        } else {
-            let comma_separated_types = self
-                .return_types
-                .iter()
-                .chain(self.argument_types.iter())
-                .map(ToString::to_string)
-                .collect::<Vec<String>>()
-                .join(", ");
-            format!("::<{comma_separated_types}>")
+    fn wasmvalue_accessor_for_type(wasm_type: &WasmType) -> String {
+        match wasm_type {
+            WasmType::I32 => "i32".to_string(),
+            WasmType::F32 => "f32".to_string(),
+            WasmType::I64 => "i64".to_string(),
+            WasmType::F64 => "f64".to_string(),
+            WasmType::Ref(RefType::ExternRef) => "extern_ref".to_string(),
+            WasmType::Ref(RefType::FuncRef) => "func_ref".to_string(),
         }
     }
-
-    fn rust_comma_separated_generics(rets_count: usize, args_count: usize) -> String {
-        if rets_count + args_count == 0 {
-            String::new()
-        } else {
-            format!(
-                "<{}>",
-                Self::rust_generics(rets_count, args_count).join(", ")
-            )
-        }
-    }
-
-    fn rust_generics(rets_count: usize, args_count: usize) -> Vec<String> {
-        let arg_typs = (0..args_count).map(|n| format!("T{n}"));
-        let ret_typs = (0..rets_count).map(|n| format!("R{n}"));
-        ret_typs.chain(arg_typs).collect::<Vec<String>>()
-    }
-
-    fn rust_generic_typed_arguments(args_count: usize) -> Vec<String> {
-        (0..args_count)
-            .clone()
-            .map(|n| format!("a{n}: T{n}"))
-            .collect::<Vec<String>>()
-    }
-
-    fn rust_generic_comma_separated_typed_arguments(args_count: usize) -> String {
-        Self::rust_generic_typed_arguments(args_count).join(", ")
-    }
-
-    fn rust_compute_type_allocation(rets_count: usize, args_count: usize) -> String {
-        if rets_count + args_count == 0 {
-            "0".to_string()
-        } else {
-            Self::rust_generics(rets_count, args_count)
-                .iter()
-                .map(|ty| format!("size_of::<{ty}>()"))
-                .collect::<Vec<String>>()
-                .join(" + ")
-        }
-    }
-}
-
-fn generics_offset(position: usize, rets_count: usize, args_offset: usize) -> String {
-    if position == 0 {
-        return "0".into();
-    };
-    let ret_offsets: Vec<String> = (0..rets_count)
-        .map(|n| format!("size_of::<R{n}>()"))
-        .collect();
-    let arg_offsets: Vec<String> = (0..args_offset)
-        .map(|n| format!("size_of::<T{n}>()"))
-        .collect();
-
-    ret_offsets
-        .into_iter()
-        .chain(arg_offsets)
-        .take(position)
-        .collect::<Vec<String>>()
-        .join(" + ")
-}
-
-fn arg_offset(arg_pos: usize, rets_count: usize, args_count: usize) -> String {
-    generics_offset(rets_count + arg_pos, rets_count, args_count)
-}
-
-fn ret_offset(ret_pos: usize, rets_count: usize, args_count: usize) -> String {
-    generics_offset(ret_pos, rets_count, args_count)
 }
 
 fn generate_allocate_generic(rets_count: usize, args_count: usize) -> String {
-    let string_all_generics = RustSignature::rust_comma_separated_generics(rets_count, args_count);
-    let signature = RustSignature::rust_generic_comma_separated_typed_arguments(args_count);
     let generic_name = RustSignature::generic_rust_name(rets_count, args_count);
-    let where_clause = RustSignature::generic_rust_where_clause(rets_count, args_count);
+    let total_slots = rets_count + args_count;
 
-    // eg: `size_of::<R0>() +  size_of::<R1>() +  size_of::<T0>() +  size_of::<T1>()`
-    let total_allocation = RustSignature::rust_compute_type_allocation(rets_count, args_count);
-    let all_stores_followed_by_return = (0..args_count)
+    if total_slots == 0 {
+        return format!(
+            "
+#[inline(always)]
+fn allocate_{generic_name}() -> usize {{
+    0 // Fake shadow pointer for empty signatures
+}}"
+        );
+    }
+
+    let store_args = (0..args_count)
         .map(|n| {
-            let offset = arg_offset(n, rets_count, args_count);
-            format!(
-                "// store a{n}
-    let a{n}_offset = {offset}; // constant folded
-    wastrumentation_memory_store::<T{n}>(shadow_frame_ptr, a{n}, a{n}_offset);
-"
-            )
+            let slot_index = rets_count + n;
+            format!("    wastrumentation_memory_store(frame_ptr, a{n}, {slot_index});")
         })
-        .chain(vec!["shadow_frame_ptr as usize".into()])
         .collect::<Vec<String>>()
-        .join("\n    ");
+        .join("\n");
+
+    let signature = (0..args_count)
+        .map(|n| format!("a{n}: WasmValue"))
+        .collect::<Vec<String>>()
+        .join(", ");
 
     format!(
         "
 #[inline(always)]
-fn allocate_{generic_name}{string_all_generics}({signature}) -> usize {where_clause} {{
-    let align = align_of::<u8>();
-    let size_to_allocate: usize = {total_allocation};
-    let layout = unsafe {{ Layout::from_size_align_unchecked(size_to_allocate, align) }};
-    let shadow_frame_ptr = unsafe {{ GlobalAlloc::alloc(&ALLOC, layout) }} as usize;
-    {all_stores_followed_by_return}
+fn allocate_{generic_name}({signature}) -> usize {{
+    let frame_ptr = stack_allocate_values({total_slots});
+{store_args}
+    frame_ptr
 }}"
     )
 }
 
 fn generate_allocate_specialized(signature: &RustSignature) -> String {
-    // eg: Signature { return_type: [`i64`, `i32`], argument_types: [`f64`, `f32`] }
-    // eg: [`f64`, `f32`]
     let signature_args = &signature.argument_types;
-    // eg: `a0, a1`
-    let args = signature_args
-        .iter()
-        .enumerate()
-        .map(|(index, _ty)| format!("a{index}"))
-        .collect::<Vec<String>>()
-        .join(", ");
-    // eg: `a0: f64, a1: f32`
     let signature_args_typs_ident = signature_args
         .iter()
         .enumerate()
@@ -208,51 +115,55 @@ fn generate_allocate_specialized(signature: &RustSignature) -> String {
         .collect::<Vec<String>>()
         .join(", ");
 
-    let comma_separated_types = signature.rust_comma_separated_types();
+    let args_converted = signature_args
+        .iter()
+        .enumerate()
+        .map(|(index, ty)| {
+            let constructor = RustSignature::wasmvalue_constructor_for_type(ty);
+            format!("{constructor}(a{index})")
+        })
+        .collect::<Vec<String>>()
+        .join(", ");
+
     let mangled_name = signature.generate_allocate_values_buffer_name();
     let mangled_by_count_name = signature.mangled_rust_name_by_count();
 
     format!(
         "
 #[no_mangle]
-pub fn {mangled_name}({signature_args_typs_ident}) -> usize {{
-    return allocate_{mangled_by_count_name}{comma_separated_types}({args});
+pub extern \"C\" fn {mangled_name}({signature_args_typs_ident}) -> usize {{
+    allocate_{mangled_by_count_name}({args_converted})
 }}
 "
     )
 }
 
 fn generate_allocate_types_buffer_generic(rets_count: usize, args_count: usize) -> String {
-    let total_allocation = format!("size_of::<i32>() * {}", rets_count + args_count);
+    let total_types = rets_count + args_count;
     let generic_name = RustSignature::generic_rust_name(rets_count, args_count);
     format!(
         "
 #[inline(always)]
 fn allocate_signature_types_buffer_{generic_name}() -> usize {{
-    let to_allocate = {total_allocation}; // constant folded
-    let stack_begin = stack_allocate(to_allocate); // inlined
-    return stack_begin;
+    stack_allocate_types({total_types}) // inlined
 }}"
     )
 }
 
 fn generate_allocate_types_buffer_specialized(signature: &RustSignature) -> String {
-    // eg: [`i64`, `i32`]
     let signature_rets = &signature.return_types;
-    // eg: [`f64`, `f32`]
     let signature_args = &signature.argument_types;
-    // eg: `i64, i32, f64, f32`
+
     let all_stores_followed_by_return = signature_rets
         .iter()
         .chain(signature_args.iter())
-        .map(WasmType::runtime_enum_value)
+        .map(WasmType::runtime_enum_variant)
         .enumerate()
-        .map(|(index, enum_value)| {
-            format!("wastrumentation_memory_store::<i32>(types_buffer, {enum_value}, size_of::<i32>()*{index});")
+        .map(|(index, enum_variant)| {
+            format!("    wastrumentation_stack_store_type(types_buffer, {index}, RuntimeType::{enum_variant});")
         })
-        .chain(vec!["return types_buffer;".into()])
         .collect::<Vec<String>>()
-        .join("\n    ");
+        .join("\n");
 
     let mangled_name = signature.generate_allocate_types_buffer_name();
     let mangled_by_count_name = signature.mangled_rust_name_by_count();
@@ -260,40 +171,38 @@ fn generate_allocate_types_buffer_specialized(signature: &RustSignature) -> Stri
     format!(
         "
 #[no_mangle]
-pub fn {mangled_name}() -> usize {{
+pub extern \"C\" fn {mangled_name}() -> usize {{
     let types_buffer = allocate_signature_types_buffer_{mangled_by_count_name}();
-    {all_stores_followed_by_return}
+{all_stores_followed_by_return}
+    types_buffer
 }}"
     )
 }
 
 fn generate_load_generic(rets_count: usize, args_count: usize) -> String {
-    let string_all_generics = RustSignature::rust_comma_separated_generics(rets_count, args_count);
     let generic_name = RustSignature::generic_rust_name(rets_count, args_count);
-    let where_clause = RustSignature::generic_rust_where_clause(rets_count, args_count);
 
     let all_arg_loads = (0..args_count).map(|n| {
-        let an_offset = arg_offset(n, rets_count, args_count);
+        let slot_index = rets_count + n;
         format!(
             "
 #[inline(always)]
-fn load_arg{n}_{generic_name}{string_all_generics}(stack_ptr: usize) -> T{n} {where_clause} {{
-    let a{n}_offset = {an_offset}; // constant folded
-    return wastrumentation_memory_load::<T{n}>(stack_ptr, a{n}_offset); // inlined
+fn load_arg{n}_{generic_name}(stack_ptr: usize) -> WasmValue {{
+    wastrumentation_memory_load(stack_ptr, {slot_index})
 }}"
         )
     });
+
     let all_ret_loads = (0..rets_count).map(|n| {
-        let ar_offset = ret_offset(n, rets_count, args_count);
         format!(
             "
 #[inline(always)]
-fn load_ret{n}_{generic_name}{string_all_generics}(stack_ptr: usize) -> R{n} {where_clause} {{
-    let r{n}_offset = {ar_offset}; // constant folded
-    return wastrumentation_memory_load::<R{n}>(stack_ptr, r{n}_offset); // inlined
+fn load_ret{n}_{generic_name}(stack_ptr: usize) -> WasmValue {{
+    wastrumentation_memory_load(stack_ptr, {n})
 }}"
         )
     });
+
     all_arg_loads
         .chain(all_ret_loads)
         .collect::<Vec<String>>()
@@ -301,40 +210,35 @@ fn load_ret{n}_{generic_name}{string_all_generics}(stack_ptr: usize) -> R{n} {wh
 }
 
 fn generate_load_specialized(signature: &RustSignature) -> String {
-    // eg: [`i64`, `i32`]
     let signature_rets = &signature.return_types;
-    // eg: [`f64`, `f32`]
     let signature_args = &signature.argument_types;
-
-    let comma_separated_types = signature.rust_comma_separated_types();
     let mangled_by_count_name = signature.mangled_rust_name_by_count();
 
-    let all_arg_loads = signature_args
-        .iter()
-        .enumerate()
-        .map(|(index, arg_i_ret_type)| {
-            let mangled_name = signature.generate_load_name(SignatureSide::Argument, index);
-            format!(
-                "
+    let all_arg_loads = signature_args.iter().enumerate().map(|(index, arg_type)| {
+        let mangled_name = signature.generate_load_name(SignatureSide::Argument, index);
+        let accessor = RustSignature::wasmvalue_accessor_for_type(arg_type);
+        format!(
+            "
 #[no_mangle]
-pub fn {mangled_name}(stack_ptr: usize) -> {arg_i_ret_type} {{
-    return load_arg{index}_{mangled_by_count_name}{comma_separated_types}(stack_ptr);
+pub extern \"C\" fn {mangled_name}(stack_ptr: usize) -> {arg_type} {{
+    let val = load_arg{index}_{mangled_by_count_name}(stack_ptr);
+    unsafe {{ val.{accessor} }}
 }}"
-            )
-        });
-    let all_ret_loads = signature_rets
-        .iter()
-        .enumerate()
-        .map(|(index, ret_i_ret_type)| {
-            let mangled_name = signature.generate_load_name(SignatureSide::Return, index);
-            format!(
-                "
+        )
+    });
+
+    let all_ret_loads = signature_rets.iter().enumerate().map(|(index, ret_type)| {
+        let mangled_name = signature.generate_load_name(SignatureSide::Return, index);
+        let accessor = RustSignature::wasmvalue_accessor_for_type(ret_type);
+        format!(
+            "
 #[no_mangle]
-pub fn {mangled_name}(stack_ptr: usize) -> {ret_i_ret_type} {{
-    return load_ret{index}_{mangled_by_count_name}{comma_separated_types}(stack_ptr);
+pub extern \"C\" fn {mangled_name}(stack_ptr: usize) -> {ret_type} {{
+    let val = load_ret{index}_{mangled_by_count_name}(stack_ptr);
+    unsafe {{ val.{accessor} }}
 }}"
-            )
-        });
+        )
+    });
 
     all_arg_loads
         .chain(all_ret_loads)
@@ -343,32 +247,29 @@ pub fn {mangled_name}(stack_ptr: usize) -> {ret_i_ret_type} {{
 }
 
 fn generate_store_generic(rets_count: usize, args_count: usize) -> String {
-    let string_all_generics = RustSignature::rust_comma_separated_generics(rets_count, args_count);
     let generic_name = RustSignature::generic_rust_name(rets_count, args_count);
-    let where_clause = RustSignature::generic_rust_where_clause(rets_count, args_count);
 
     let all_arg_stores = (0..args_count).map(|n| {
-        let an_offset = arg_offset(n, rets_count, args_count);
+        let slot_index = rets_count + n;
         format!(
             "
 #[inline(always)]
-fn store_arg{n}_{generic_name}{string_all_generics}(stack_ptr: usize, a{n}: T{n}) {where_clause} {{
-    let a{n}_offset: usize = {an_offset}; // constant folded
-    return wastrumentation_memory_store::<T{n}>(stack_ptr, a{n}, a{n}_offset); // inlined
+fn store_arg{n}_{generic_name}(stack_ptr: usize, a{n}: WasmValue) {{
+    wastrumentation_memory_store(stack_ptr, a{n}, {slot_index});
 }}"
         )
     });
+
     let all_ret_stores = (0..rets_count).map(|n| {
-        let ar_offset = ret_offset(n, rets_count, args_count);
         format!(
             "
 #[inline(always)]
-fn store_ret{n}_{generic_name}{string_all_generics}(stack_ptr: usize, r{n}: R{n}) {where_clause} {{
-    let r{n}_offset: usize = {ar_offset}; // constant folded
-    return wastrumentation_memory_store::<R{n}>(stack_ptr, r{n}, r{n}_offset); // inlined
+fn store_ret{n}_{generic_name}(stack_ptr: usize, r{n}: WasmValue) {{
+    wastrumentation_memory_store(stack_ptr, r{n}, {n});
 }}"
         )
     });
+
     all_arg_stores
         .chain(all_ret_stores)
         .collect::<Vec<String>>()
@@ -376,40 +277,34 @@ fn store_ret{n}_{generic_name}{string_all_generics}(stack_ptr: usize, r{n}: R{n}
 }
 
 fn generate_store_specialized(signature: &RustSignature) -> String {
-    // eg: [`i64`, `i32`]
     let signature_rets = &signature.return_types;
-    // eg: [`f64`, `f32`]
     let signature_args = &signature.argument_types;
-
-    let comma_separated_types = signature.rust_comma_separated_types();
     let mangled_by_count_name = signature.mangled_rust_name_by_count();
 
-    let all_arg_stores = signature_args
-        .iter()
-        .enumerate()
-        .map(|(index, arg_i_ret_type)| {
-            let mangled_name = signature.generate_store_name(SignatureSide::Argument, index);
-            format!(
-                "
+    let all_arg_stores = signature_args.iter().enumerate().map(|(index, arg_type)| {
+        let mangled_name = signature.generate_store_name(SignatureSide::Argument, index);
+        let constructor = RustSignature::wasmvalue_constructor_for_type(arg_type);
+        format!(
+            "
 #[no_mangle]
-pub fn {mangled_name}(stack_ptr: usize, a{index}: {arg_i_ret_type}) {{
-    return store_arg{index}_{mangled_by_count_name}{comma_separated_types}(stack_ptr, a{index});
+pub extern \"C\" fn {mangled_name}(stack_ptr: usize, a{index}: {arg_type}) {{
+    store_arg{index}_{mangled_by_count_name}(stack_ptr, {constructor}(a{index}));
 }}"
-            )
-        });
-    let all_ret_stores = signature_rets
-        .iter()
-        .enumerate()
-        .map(|(index, ret_i_ret_type)| {
-            let mangled_name = signature.generate_store_name(SignatureSide::Return, index);
-            format!(
-                "
+        )
+    });
+
+    let all_ret_stores = signature_rets.iter().enumerate().map(|(index, ret_type)| {
+        let mangled_name = signature.generate_store_name(SignatureSide::Return, index);
+        let constructor = RustSignature::wasmvalue_constructor_for_type(ret_type);
+        format!(
+            "
 #[no_mangle]
-pub fn {mangled_name}(stack_ptr: usize, a{index}: {ret_i_ret_type}) {{
-    return store_ret{index}_{mangled_by_count_name}{comma_separated_types}(stack_ptr, a{index});
+pub extern \"C\" fn {mangled_name}(stack_ptr: usize, a{index}: {ret_type}) {{
+    store_ret{index}_{mangled_by_count_name}(stack_ptr, {constructor}(a{index}));
 }}"
-            )
-        });
+        )
+    });
+
     all_arg_stores
         .chain(all_ret_stores)
         .collect::<Vec<String>>()
@@ -417,20 +312,24 @@ pub fn {mangled_name}(stack_ptr: usize, a{index}: {ret_i_ret_type}) {{
 }
 
 fn generate_free_values_buffer_generic(rets_count: usize, args_count: usize) -> String {
-    let string_all_generics = RustSignature::rust_comma_separated_generics(rets_count, args_count);
     let generic_name = RustSignature::generic_rust_name(rets_count, args_count);
-    let where_clause = RustSignature::generic_rust_where_clause(rets_count, args_count);
+    let total_slots = rets_count + args_count;
 
-    // eg: `size_of::<R0>() +  size_of::<R1>() +  size_of::<T0>() +  size_of::<T1>()`
-    let total_allocation = RustSignature::rust_compute_type_allocation(rets_count, args_count);
+    if total_slots == 0 {
+        return format!(
+            "
+#[inline(always)]
+fn free_values_{generic_name}(_ptr: usize) {{
+    // No deallocation for empty signatures
+}}"
+        );
+    }
 
     format!(
         "
 #[inline(always)]
-fn free_values_{generic_name}{string_all_generics}(ptr: usize) {where_clause} {{
-    let to_deallocate = {total_allocation}; // constant folded
-    stack_deallocate(ptr, to_deallocate); // inlined
-    return;
+fn free_values_{generic_name}(ptr: usize) {{
+    stack_deallocate_values(ptr, {total_slots});
 }}"
     )
 }
@@ -439,26 +338,23 @@ fn generate_free_values_buffer_specialized(signature: &RustSignature) -> String 
     format!(
         "
 #[no_mangle]
-pub fn {}(ptr: usize) {{
-    return free_values_{}{}(ptr);
+pub extern \"C\" fn {}(ptr: usize) {{
+    free_values_{}(ptr);
 }}",
         signature.generate_free_values_buffer_name(),
         signature.mangled_rust_name_by_count(),
-        signature.rust_comma_separated_types(),
     )
 }
 
 fn generate_free_types_buffer_generic(rets_count: usize, args_count: usize) -> String {
     let generic_name = RustSignature::generic_rust_name(rets_count, args_count);
-    let total_allocation = format!("size_of::<i32>() * {}", rets_count + args_count);
+    let total_types = rets_count + args_count;
 
     format!(
         "
 #[inline(always)]
 fn free_types_{generic_name}(ptr: usize) {{
-    let to_deallocate = {total_allocation}; // constant folded
-    stack_deallocate(ptr, to_deallocate); // inlined
-    return;
+    stack_deallocate_types(ptr, {total_types});
 }}"
     )
 }
@@ -467,8 +363,8 @@ fn generate_free_types_buffer_specialized(signature: &RustSignature) -> String {
     format!(
         "
 #[no_mangle]
-pub fn {}(ptr: usize) {{
-    return free_types_{}(ptr);
+pub extern \"C\" fn {}(ptr: usize) {{
+    free_types_{}(ptr);
 }}",
         signature.generate_free_types_buffer_name(),
         signature.mangled_rust_name_by_count(),
@@ -476,94 +372,183 @@ pub fn {}(ptr: usize) {{
 }
 
 fn generate_store_rets_generic(rets_count: usize, args_count: usize) -> String {
-    let string_all_generics = RustSignature::rust_comma_separated_generics(rets_count, args_count);
     let generic_name = RustSignature::generic_rust_name(rets_count, args_count);
-    let where_clause = RustSignature::generic_rust_where_clause(rets_count, args_count);
 
-    // eg: [`a0: R0`, `a1: R1`]
-    let array_of_rets_signature = (0..rets_count).map(|n| format!("a{n}: R{n}"));
+    let array_of_rets_signature = (0..rets_count).map(|n| format!("a{n}: WasmValue"));
     let stack_ptr = String::from(if rets_count == 0 {
         "_stack_ptr: usize"
     } else {
         "stack_ptr: usize"
     });
+
     let total_signature = (vec![stack_ptr])
         .into_iter()
         .chain(array_of_rets_signature)
         .collect::<Vec<String>>()
         .join(", ");
+
     let all_stores = (0..rets_count)
-        .flat_map(|n| {
-            vec![
-                format!("// store a{n}"),
-                format!("store_ret{n}_{generic_name}::{string_all_generics}(stack_ptr, a{n});"),
-            ]
-        })
-        .chain(vec!["return;".into()])
+        .map(|n| format!("    store_ret{n}_{generic_name}(stack_ptr, a{n});"))
         .collect::<Vec<String>>()
-        .join("\n    ");
+        .join("\n");
 
     format!(
         "
 #[inline(always)]
-fn store_rets_{generic_name}{string_all_generics}({total_signature}) {where_clause} {{
-    {all_stores}
+fn store_rets_{generic_name}({total_signature}) {{
+{all_stores}
 }}"
     )
 }
 
 fn generate_store_rets_specialized(signature: &RustSignature) -> String {
-    // eg: [`i64`, `i32`]
     let signature_rets = &signature.return_types;
-    // eg: [`a0`, `a1`]
-    let rets_arguments = signature_rets
-        .iter()
-        .enumerate()
-        .map(|(index, _type)| format!("a{index}"));
-    // eg: [`a0: R0`, `a1: R1`]
+
     let rets_signature = signature_rets
         .iter()
         .enumerate()
         .map(|(index, ty)| format!("a{index}: {ty}"));
-    // eg: `stack_ptr: usize, a0: R0, a1: R1`
+
     let total_signature = (vec![String::from("stack_ptr: usize")])
         .into_iter()
         .chain(rets_signature)
         .collect::<Vec<String>>()
         .join(", ");
-    // eg: `stack_ptr, a0, a1`
-    let total_arguments = (vec![String::from("stack_ptr")])
-        .into_iter()
-        .chain(rets_arguments)
+
+    let args_converted = signature_rets
+        .iter()
+        .enumerate()
+        .map(|(index, ty)| {
+            let constructor = RustSignature::wasmvalue_constructor_for_type(ty);
+            format!("{constructor}(a{index})")
+        })
         .collect::<Vec<String>>()
         .join(", ");
 
-    let comma_separated_types = signature.rust_comma_separated_types();
+    let total_arguments = if signature_rets.is_empty() {
+        "stack_ptr".to_string()
+    } else {
+        format!("stack_ptr, {args_converted}")
+    };
+
     let mangled_name = signature.generate_store_rets_name();
     let mangled_by_count_name = signature.mangled_rust_name_by_count();
 
     format!(
         "
 #[no_mangle]
-pub fn {mangled_name}({total_signature}) {{
-    return store_rets_{mangled_by_count_name}{comma_separated_types}({total_arguments});
+pub extern \"C\" fn {mangled_name}({total_signature}) {{
+    store_rets_{mangled_by_count_name}({total_arguments});
 }}"
     )
 }
 
+// The `#[allow(unused)]` attributes are present to allow
+// for the generated code to not necesarily make use of all
+// surrounding functions.
+
 const LIB_BOILERPLATE: &str = r#"
+// TODO: Allow to enable / disable `no_std` based on some flag
 #![no_std]
 
-use core::mem::{size_of, align_of};
+#![allow(clippy::let_and_return)]
+#![allow(clippy::too_many_arguments)]
+#![allow(clippy::inline_always)]
+
 use core::alloc::{GlobalAlloc, Layout};
+use core::mem::{align_of, size_of};
 
 extern crate wee_alloc;
 #[global_allocator]
 pub static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
-// Optionally use primitives from core::arch::wasm
-// https://doc.rust-lang.org/stable/core/arch/wasm/index.html
+#[allow(unused)]
+const COMPILE_TIME_CHECKS: bool = {
+    assert!(size_of::<RuntimeType>() == size_of::<i32>());
+    true
+};
 
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)] // Up-front, it is not known which variants will be constructed
+enum RuntimeType {
+    I32 = 0,
+    F32 = 1,
+    I64 = 2,
+    F64 = 3,
+    FuncRef = 4,
+    ExternRef = 5,
+}
+
+impl From<RuntimeType> for i32 {
+    #[inline(always)]
+    fn from(value: RuntimeType) -> Self {
+        value as i32
+    }
+}
+
+#[cfg(debug_assertions)]
+impl RuntimeType {
+    fn assert_can_come_from(value: i32, cast_runtime_type: Self) {
+        let slow_convert = match value {
+            0 => Self::I32,
+            1 => Self::F32,
+            2 => Self::I64,
+            3 => Self::F64,
+            4 => Self::FuncRef,
+            5 => Self::ExternRef,
+            _ => panic!("cannot cast {value} to runtime type"),
+        };
+        assert_eq!(cast_runtime_type, slow_convert);
+    }
+}
+
+impl From<i32> for RuntimeType {
+    #[inline(always)]
+    fn from(value: i32) -> Self {
+        let cast = unsafe { core::mem::transmute::<i32, RuntimeType>(value) };
+
+        #[cfg(debug_assertions)]
+        RuntimeType::assert_can_come_from(value, cast);
+
+        cast
+    }
+}
+
+// Union for WASM values
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union WasmValue {
+    pub i32: i32,
+    pub f32: f32,
+    pub i64: i64,
+    pub f64: f64,
+    pub ref_type: RefType,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub enum RefType {
+    FuncRef,
+    ExternRef,
+}
+
+impl WasmValue {
+    #[inline(always)] #[must_use]
+    pub const fn new_i32(val: i32) -> Self { WasmValue { i32: val } }
+    #[inline(always)] #[must_use]
+    pub const fn new_f32(val: f32) -> Self { WasmValue { f32: val } }
+    #[inline(always)] #[must_use]
+    pub const fn new_i64(val: i64) -> Self { WasmValue { i64: val } }
+    #[inline(always)] #[must_use]
+    pub const fn new_f64(val: f64) -> Self { WasmValue { f64: val } }
+    #[inline(always)] #[must_use]
+    pub const fn new_func_ref() -> Self { WasmValue { ref_type: RefType::FuncRef } }
+    #[inline(always)] #[must_use]
+    pub const fn new_extern_ref() -> Self { WasmValue { ref_type: RefType::ExternRef } }
+}
+
+#[cfg(not(test))]
 #[panic_handler]
 fn panic(_panic: &core::panic::PanicInfo<'_>) -> ! {
     #[cfg(not(target_arch = "wasm32"))]
@@ -573,72 +558,111 @@ fn panic(_panic: &core::panic::PanicInfo<'_>) -> ! {
 }
 
 #[inline(always)]
-fn wastrumentation_memory_load<T: Copy>(stack_ptr: usize, offset: usize) -> T {
-    let ptr: *const u8 = stack_ptr as *const u8;
-    unsafe { *(ptr.offset(offset as isize) as *const T) }
+fn wastrumentation_memory_load(stack_ptr: usize, offset: usize) -> WasmValue {
+    let ptr = stack_ptr as *const WasmValue;
+    unsafe { *ptr.add(offset) }
 }
 
 #[inline(always)]
-fn wastrumentation_memory_store<T>(stack_ptr: usize, value: T, offset: usize) {
-    let ptr: *mut u8 = stack_ptr as *mut u8;
-    unsafe {
-        *(ptr.offset(offset as isize) as *mut T) = value;
-    }
+fn wastrumentation_memory_store(stack_ptr: usize, value: WasmValue, offset: usize) {
+    let ptr = stack_ptr as *mut WasmValue;
+    unsafe { *ptr.add(offset) = value };
 }
 
-#[inline(always)]
-fn stack_allocate(bytes_to_allocate: usize) -> usize {
-    let align = align_of::<u8>();
-    let layout: Layout = unsafe { Layout::from_size_align_unchecked(bytes_to_allocate, align) };
-    let shadow_frame_ptr = unsafe { ALLOC.alloc(layout) } as usize;
-    shadow_frame_ptr
+// Pre-compute common layout for RuntimeType
+const RUNTIME_TYPE_LAYOUT: Layout = unsafe {
+    Layout::from_size_align_unchecked(size_of::<RuntimeType>(), align_of::<RuntimeType>())
+};
+
+#[inline(always)] #[allow(unused)]
+fn stack_allocate_types(count: usize) -> usize {
+    let size = size_of::<RuntimeType>() * count;
+    let layout = unsafe { Layout::from_size_align_unchecked(size, RUNTIME_TYPE_LAYOUT.align()) };
+    unsafe { ALLOC.alloc(layout) as usize }
 }
 
-#[inline(always)]
-fn stack_deallocate(ptr: usize, bytes_to_allocate: usize) {
-    let align = align_of::<u8>();
-    let layout: Layout = unsafe { Layout::from_size_align_unchecked(bytes_to_allocate, align) };
+#[inline(always)] #[allow(unused)]
+fn stack_deallocate_types(ptr: usize, count: usize) {
+    let size = size_of::<RuntimeType>() * count;
+    let layout = unsafe { Layout::from_size_align_unchecked(size, RUNTIME_TYPE_LAYOUT.align()) };
+    let ptr = ptr as *mut u8;
+    unsafe { ALLOC.dealloc(ptr, layout) };
+}
+
+// Pre-compute common layout for WasmValue
+const WASM_VALUE_LAYOUT: Layout =
+    unsafe { Layout::from_size_align_unchecked(size_of::<WasmValue>(), align_of::<WasmValue>()) };
+
+#[inline(always)] #[allow(unused)]
+fn stack_allocate_values(num_values: usize) -> usize {
+    let size = num_values * WASM_VALUE_LAYOUT.size();
+    let layout = unsafe { Layout::from_size_align_unchecked(size, WASM_VALUE_LAYOUT.align()) };
+    (unsafe { ALLOC.alloc(layout) } as usize)
+}
+
+#[inline(always)] #[allow(unused)]
+fn stack_deallocate_values(ptr: usize, num_values: usize) {
+    let size = num_values * WASM_VALUE_LAYOUT.size();
+    let layout = unsafe { Layout::from_size_align_unchecked(size, WASM_VALUE_LAYOUT.align()) };
     unsafe { ALLOC.dealloc(ptr as *mut u8, layout) };
 }
 
+#[inline(always)] #[allow(unused)]
+fn wastrumentation_stack_store_type(ptr: usize, offset: usize, ty: RuntimeType) {
+    let ptr = ptr as *mut RuntimeType;
+    unsafe { *ptr.add(offset) = ty };
+}
+
+#[no_mangle]
+pub extern "C" fn wastrumentation_stack_load_type(ptr: usize, offset: usize) -> i32 {
+    let ptr = ptr as *const RuntimeType;
+    let ty = unsafe { *ptr.add(offset) };
+    ty.into()
+}
+
+// Optimized load/store functions
 #[no_mangle]
 pub extern "C" fn wastrumentation_stack_load_i32(ptr: usize, offset: usize) -> i32 {
-    wastrumentation_memory_load::<i32>(ptr, offset)
+    let wasm_val = wastrumentation_memory_load(ptr, offset);
+    unsafe { wasm_val.i32 }
 }
 
 #[no_mangle]
 pub extern "C" fn wastrumentation_stack_load_f32(ptr: usize, offset: usize) -> f32 {
-    wastrumentation_memory_load::<f32>(ptr, offset)
+    let wasm_val = wastrumentation_memory_load(ptr, offset);
+    unsafe { wasm_val.f32 }
 }
 
 #[no_mangle]
 pub extern "C" fn wastrumentation_stack_load_i64(ptr: usize, offset: usize) -> i64 {
-    wastrumentation_memory_load::<i64>(ptr, offset)
+    let wasm_val = wastrumentation_memory_load(ptr, offset);
+    unsafe { wasm_val.i64 }
 }
 
 #[no_mangle]
 pub extern "C" fn wastrumentation_stack_load_f64(ptr: usize, offset: usize) -> f64 {
-    wastrumentation_memory_load::<f64>(ptr, offset)
+    let wasm_val = wastrumentation_memory_load(ptr, offset);
+    unsafe { wasm_val.f64 }
 }
 
 #[no_mangle]
 pub extern "C" fn wastrumentation_stack_store_i32(ptr: usize, value: i32, offset: usize) {
-    wastrumentation_memory_store::<i32>(ptr, value, offset)
+    wastrumentation_memory_store(ptr, WasmValue::new_i32(value), offset);
 }
 
 #[no_mangle]
 pub extern "C" fn wastrumentation_stack_store_f32(ptr: usize, value: f32, offset: usize) {
-    wastrumentation_memory_store::<f32>(ptr, value, offset)
+    wastrumentation_memory_store(ptr, WasmValue::new_f32(value), offset);
 }
 
 #[no_mangle]
 pub extern "C" fn wastrumentation_stack_store_i64(ptr: usize, value: i64, offset: usize) {
-    wastrumentation_memory_store::<i64>(ptr, value, offset)
+    wastrumentation_memory_store(ptr, WasmValue::new_i64(value), offset);
 }
 
 #[no_mangle]
 pub extern "C" fn wastrumentation_stack_store_f64(ptr: usize, value: f64, offset: usize) {
-    wastrumentation_memory_store::<f64>(ptr, value, offset)
+    wastrumentation_memory_store(ptr, WasmValue::new_f64(value), offset);
 }
 "#;
 

--- a/wastrumentation-instr-lib/src/lib_gen/instrumentation/rust/tests/test_edge_case.rs
+++ b/wastrumentation-instr-lib/src/lib_gen/instrumentation/rust/tests/test_edge_case.rs
@@ -90,8 +90,7 @@ fn test_edge_rust() {
     let _ = instrumentation_wasm_library;
 
     // Assert execution
-    // FIXME:
-    // assert_lib_with_use_case(instrumentation_wasm_library);
+    assert_lib_with_use_case(instrumentation_wasm_library);
 }
 
 #[test]

--- a/wastrumentation-instr-lib/tests/analyses/wasp-as/signatures_check.wasp
+++ b/wastrumentation-instr-lib/tests/analyses/wasp-as/signatures_check.wasp
@@ -43,20 +43,20 @@
           validate_post_call_values(expected_values: WasmValue[], actual_values: DynValues): void {
             assert(actual_values.length === expected_values.length);
             for (let index = 0; index < expected_values.length; index++) {
-              const wasm_value = expected_values[index];
-              assert(wasm_value.wasm_type === actual_values.getType(index));
-              switch (wasm_value.wasm_type) {
+              const expected_value = expected_values[index];
+              assert(expected_value.wasm_type === actual_values.getType(index));
+              switch (expected_value.wasm_type) {
                 case WasmType.i32:
-                  assert(wasm_value.as_i32() === actual_values.get<i32>(index));
+                  assert(expected_value.as_i32() === actual_values.get<i32>(index));
                   break;
                 case WasmType.f32:
-                  assert(wasm_value.as_f32() === actual_values.get<f32>(index));
+                  assert(expected_value.as_f32() === actual_values.get<f32>(index));
                   break;
                 case WasmType.i64:
-                  assert(wasm_value.as_i64() === actual_values.get<i64>(index));
+                  assert(expected_value.as_i64() === actual_values.get<i64>(index));
                   break;
                 case WasmType.f64:
-                  assert(wasm_value.as_f64() === actual_values.get<f64>(index));
+                  assert(expected_value.as_f64() === actual_values.get<f64>(index));
                   break;
                 default:
                   unreachable();

--- a/wastrumentation-instr-lib/tests/integration_tests.rs
+++ b/wastrumentation-instr-lib/tests/integration_tests.rs
@@ -485,7 +485,7 @@ fn test_analysis_logging() {
 
     const EXPECTED_ANALYSIS_STDOUT: &str = indoc::indoc! { r#"
     [ANALYSIS:] apply (pre) WasmFunction {
-        uninstr_idx: 1,
+        uninstr_idx: 0,
         sig_pointer: 1179632,
     }(RuntimeValues {
         argc: 1,
@@ -496,91 +496,91 @@ fn test_analysis_logging() {
             I32,
         ],
     })
-    [ANALYSIS:] block pre [block_input_count: BlockInputCount(0), block_arity: BlockArity(0)], location: Location { instr_index: 1, funct_index: 0 }
+    [ANALYSIS:] block pre [block_input_count: BlockInputCount(0), block_arity: BlockArity(0)], location: Location { instr_index: 0, funct_index: 0 }
     [ANALYSIS:] local generic I32(
         123,
     ) @ LocalIndex(
         0,
-    ) : Get, location: Location { instr_index: 1, funct_index: 1 }
+    ) : Get, location: Location { instr_index: 0, funct_index: 1 }
     [ANALYSIS:] br_if ParameterBrIfCondition(
         123,
     ) to ParameterBrIfLabel(
         0,
-    ), location: Location { instr_index: 1, funct_index: 2 }
+    ), location: Location { instr_index: 0, funct_index: 2 }
     [ANALYSIS:] const_ generic I32(
         0,
-    ), location: Location { instr_index: 1, funct_index: 6 }
+    ), location: Location { instr_index: 0, funct_index: 6 }
     [ANALYSIS:] const_ generic I32(
         0,
-    ), location: Location { instr_index: 1, funct_index: 7 }
+    ), location: Location { instr_index: 0, funct_index: 7 }
     [ANALYSIS:] load generic I32Load @ (CONST LoadOffset(
         1048576,
     ) + LoadIndex(
         0,
     )) -> I32(
         0,
-    ), location: Location { instr_index: 1, funct_index: 8 }
+    ), location: Location { instr_index: 0, funct_index: 8 }
     [ANALYSIS:] const_ generic I32(
         4,
-    ), location: Location { instr_index: 1, funct_index: 9 }
+    ), location: Location { instr_index: 0, funct_index: 9 }
     [ANALYSIS:] binary generic I32Add I32(
         0,
     ) I32(
         4,
-    ), location: Location { instr_index: 1, funct_index: 10 }
+    ), location: Location { instr_index: 0, funct_index: 10 }
     [ANALYSIS:] store generic I32Store @ (CONST StoreOffset(
         1048576,
     ) + StoreIndex(
         0,
     )) <- I32(
         4,
-    ), location: Location { instr_index: 1, funct_index: 11 }
+    ), location: Location { instr_index: 0, funct_index: 11 }
     [ANALYSIS:] local generic I32(
         123,
     ) @ LocalIndex(
         0,
-    ) : Get, location: Location { instr_index: 1, funct_index: 12 }
+    ) : Get, location: Location { instr_index: 0, funct_index: 12 }
     [ANALYSIS:] const_ generic I32(
         20,
-    ), location: Location { instr_index: 1, funct_index: 13 }
+    ), location: Location { instr_index: 0, funct_index: 13 }
     [ANALYSIS:] binary generic I32Mul I32(
         123,
     ) I32(
         20,
-    ), location: Location { instr_index: 1, funct_index: 14 }
+    ), location: Location { instr_index: 0, funct_index: 14 }
     [ANALYSIS:] const_ generic I32(
         35,
-    ), location: Location { instr_index: 1, funct_index: 15 }
+    ), location: Location { instr_index: 0, funct_index: 15 }
     [ANALYSIS:] binary generic I32Add I32(
         2460,
     ) I32(
         35,
-    ), location: Location { instr_index: 1, funct_index: 16 }
+    ), location: Location { instr_index: 0, funct_index: 16 }
     [ANALYSIS:] const_ generic I32(
         1,
-    ), location: Location { instr_index: 1, funct_index: 17 }
+    ), location: Location { instr_index: 0, funct_index: 17 }
     [ANALYSIS:] binary generic I32ShrS I32(
         2495,
     ) I32(
         1,
-    ), location: Location { instr_index: 1, funct_index: 18 }
+    ), location: Location { instr_index: 0, funct_index: 18 }
     [ANALYSIS:] local generic I32(
         1247,
     ) @ LocalIndex(
         0,
-    ) : Tee, location: Location { instr_index: 1, funct_index: 19 }
+    ) : Tee, location: Location { instr_index: 0, funct_index: 19 }
     [ANALYSIS:] local generic I32(
         1247,
     ) @ LocalIndex(
         0,
-    ) : Get, location: Location { instr_index: 1, funct_index: 20 }
+    ) : Get, location: Location { instr_index: 0, funct_index: 20 }
     [ANALYSIS:] binary generic I32Mul I32(
         1247,
     ) I32(
         1247,
-    ), location: Location { instr_index: 1, funct_index: 21 }
+    ), location: Location { instr_index: 0, funct_index: 21 }
     [ANALYSIS:] apply (post) WasmFunction {
-        uninstr_idx: 1,
+        uninstr_idx: 0,
         sig_pointer: 1179632,
     }(RuntimeValues {
         argc: 1,

--- a/wastrumentation-instr-lib/tests/integration_tests.rs
+++ b/wastrumentation-instr-lib/tests/integration_tests.rs
@@ -486,18 +486,14 @@ fn test_analysis_logging() {
     const EXPECTED_ANALYSIS_STDOUT: &str = indoc::indoc! { r#"
     [ANALYSIS:] apply (pre) WasmFunction {
         uninstr_idx: 1,
-        sig_pointer: 1179640,
+        sig_pointer: 1179632,
     }(RuntimeValues {
         argc: 1,
         resc: 1,
-        sigv: 1179640,
+        sigv: 1179632,
         signature_types: [
             I32,
             I32,
-        ],
-        signature_offsets: [
-            0,
-            4,
         ],
     })
     [ANALYSIS:] block pre [block_input_count: BlockInputCount(0), block_arity: BlockArity(0)], location: Location { instr_index: 1, funct_index: 0 }
@@ -585,30 +581,22 @@ fn test_analysis_logging() {
     ), location: Location { instr_index: 1, funct_index: 21 }
     [ANALYSIS:] apply (post) WasmFunction {
         uninstr_idx: 1,
-        sig_pointer: 1179640,
+        sig_pointer: 1179632,
     }(RuntimeValues {
         argc: 1,
         resc: 1,
-        sigv: 1179640,
+        sigv: 1179632,
         signature_types: [
             I32,
             I32,
-        ],
-        signature_offsets: [
-            0,
-            4,
         ],
     }) = RuntimeValues {
         argc: 1,
         resc: 1,
-        sigv: 1179640,
+        sigv: 1179632,
         signature_types: [
             I32,
             I32,
-        ],
-        signature_offsets: [
-            0,
-            4,
         ],
     }
     "# };

--- a/wastrumentation-instr-lib/tests/memoization_analysis.rs
+++ b/wastrumentation-instr-lib/tests/memoization_analysis.rs
@@ -52,7 +52,7 @@ fn test_basic() {
     let time_elapsed_after_instrumented_call = report.instrumented_duration;
 
     assert_eq!(report.runtime_pure_function_calls.len(), 3);
-    assert_eq!(report.runtime_target_functions, vec![4]);
+    assert_eq!(report.runtime_target_functions, vec![2]);
 
     dbg!(report.cache_size_report);
     dbg!(report.cache_hit_report);

--- a/wastrumentation/src/wasm_constructs/mod.rs
+++ b/wastrumentation/src/wasm_constructs/mod.rs
@@ -16,6 +16,17 @@ pub enum RefType {
 }
 
 impl WasmType {
+    pub fn runtime_enum_variant(&self) -> String {
+        match self {
+            WasmType::I32 => "I32".to_string(),
+            WasmType::F32 => "F32".to_string(),
+            WasmType::I64 => "I64".to_string(),
+            WasmType::F64 => "F64".to_string(),
+            WasmType::Ref(RefType::FuncRef) => "FuncRef".to_string(),
+            WasmType::Ref(RefType::ExternRef) => "ExternRef".to_string(),
+        }
+    }
+
     pub fn runtime_enum_value(&self) -> usize {
         match self {
             WasmType::I32 => 0,


### PR DESCRIPTION
Include Rust as a language option for the instrumentation infrastructure generation

The following changes affect both Rust and AssemblyScript as instrumentation infrastructure languages, since they are about the API. Visually speaking, the README architecture ② and ④ their communication API.
- Communication between the instrumentation & analysis happens with indices of serialised values
  - Before this used to be byte offsets
- Remove ahead-of-use offset buffer computation `signature_offsets`
  - Before this used to be computed always. Now this computation takes place when the value is accessed
- Separate the store/load of serialized types and values in low-level instr API
  - In this way the API is more explicit